### PR TITLE
Add CMS page controllers, views, and tests

### DIFF
--- a/app/Contracts/FileServiceInterface.php
+++ b/app/Contracts/FileServiceInterface.php
@@ -12,4 +12,6 @@ interface FileServiceInterface
     public function updateFiles(Model $model, Request $request, array $fields, string $baseFolder): void;
 
     public function deleteFile(string $filename, string $folder): void;
+
+    public function uploadSingle(Request $request, string $field, string $baseFolder, ?string $existing = null): ?string;
 }

--- a/app/Http/Controllers/Admin/Cms/BasePageContentController.php
+++ b/app/Http/Controllers/Admin/Cms/BasePageContentController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Cms;
+
+use App\Contracts\FileServiceInterface;
+use App\Http\Controllers\Controller;
+use App\Models\Page;
+use App\Models\PageSection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+abstract class BasePageContentController extends Controller
+{
+    protected FileServiceInterface $fileService;
+
+    /**
+     * @var string[]
+     */
+    protected array $locales;
+
+    protected string $primaryLocale;
+
+    protected string $fallbackLocale;
+
+    public function __construct(FileServiceInterface $fileService)
+    {
+        $this->fileService = $fileService;
+        $default = config('app.locale', 'ar');
+        $fallback = config('app.fallback_locale', 'en');
+
+        $this->primaryLocale = $default;
+        $this->fallbackLocale = $fallback;
+
+        $locales = array_filter(array_unique([
+            $default,
+            $fallback,
+            'ar',
+            'en',
+        ]));
+
+        $this->locales = array_values($locales);
+    }
+
+    protected function loadPage(string $slug): Page
+    {
+        return Page::whereSlug($slug)
+            ->with(['sections' => function ($query) {
+                $query->orderBy('order')->with(['items' => function ($items) {
+                    $items->orderBy('order');
+                }]);
+            }])
+            ->firstOrFail();
+    }
+
+    protected function sectionByType(Collection $sections, string $type): ?PageSection
+    {
+        return $sections->firstWhere('type', $type);
+    }
+
+    protected function getSectionTranslations(?PageSection $section): array
+    {
+        $translations = [];
+
+        foreach ($this->locales as $locale) {
+            $value = $section?->getTranslation('section_data', $locale, true);
+
+            if (is_string($value)) {
+                $decoded = json_decode($value, true);
+                $value = json_last_error() === JSON_ERROR_NONE ? $decoded : [];
+            }
+
+            $translations[$locale] = is_array($value) ? $value : [];
+        }
+
+        return $translations;
+    }
+
+    protected function getItemsTranslations(?PageSection $section): array
+    {
+        if (!$section) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($section->items as $item) {
+            $translations = [];
+
+            foreach ($this->locales as $locale) {
+                $value = $item->getTranslation('data', $locale, true);
+
+                if (is_string($value)) {
+                    $decoded = json_decode($value, true);
+                    $value = json_last_error() === JSON_ERROR_NONE ? $decoded : [];
+                }
+
+                $translations[$locale] = is_array($value) ? $value : [];
+            }
+
+            $items[$item->id] = $translations;
+        }
+
+        return $items;
+    }
+
+    protected function upload(Request $request, string $field, string $folder, ?string $existing = null): ?string
+    {
+        return $this->fileService->uploadSingle($request, $field, $folder, $existing);
+    }
+}

--- a/app/Http/Controllers/Admin/Cms/ContactUsPageContentController.php
+++ b/app/Http/Controllers/Admin/Cms/ContactUsPageContentController.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Cms;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class ContactUsPageContentController extends BasePageContentController
+{
+    public function edit(string $lang)
+    {
+        $page = $this->loadPage('contact-us');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('second_banner');
+        $contact = $sections->get('contact_us');
+        $map = $sections->get('map');
+        $bottom = $sections->get('bottom_banner');
+        $ads = $sections->get('contact_form_ads');
+        $screens = $sections->get('contact_form_screens');
+        $create = $sections->get('contact_form_create');
+        $faq = $sections->get('contact_form_faq');
+
+        return view('admin.cms.contact-us.edit', [
+            'page' => $page,
+            'locales' => $this->locales,
+            'banner' => $banner,
+            'bannerData' => $this->getSectionTranslations($banner),
+            'contact' => $contact,
+            'contactData' => $this->getSectionTranslations($contact),
+            'map' => $map,
+            'mapData' => $this->getSectionTranslations($map),
+            'bottom' => $bottom,
+            'bottomData' => $this->getSectionTranslations($bottom),
+            'adsForm' => $ads,
+            'adsData' => $this->getSectionTranslations($ads),
+            'screensForm' => $screens,
+            'screensData' => $this->getSectionTranslations($screens),
+            'createForm' => $create,
+            'createData' => $this->getSectionTranslations($create),
+            'faqForm' => $faq,
+            'faqData' => $this->getSectionTranslations($faq),
+        ]);
+    }
+
+    public function update(string $lang, Request $request)
+    {
+        $page = $this->loadPage('contact-us');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('second_banner');
+        $contact = $sections->get('contact_us');
+        $map = $sections->get('map');
+        $bottom = $sections->get('bottom_banner');
+        $ads = $sections->get('contact_form_ads');
+        $screens = $sections->get('contact_form_screens');
+        $create = $sections->get('contact_form_create');
+        $faq = $sections->get('contact_form_faq');
+
+        $rules = [
+            'banner.image' => ['nullable', 'file', 'image', 'max:20480'],
+            'map.background_image' => ['nullable', 'file', 'image', 'max:20480'],
+            'bottom.image' => ['nullable', 'file', 'image', 'max:20480'],
+        ];
+
+        foreach ($this->locales as $locale) {
+            $rules["contact.$locale.title"] = ['nullable', 'string', 'max:255'];
+            $rules["contact.$locale.subtitle"] = ['nullable', 'string'];
+
+            $rules["map.$locale.title"] = ['nullable', 'string', 'max:255'];
+            $rules["map.$locale.address"] = ['nullable', 'string'];
+            $rules["map.$locale.phone_label"] = ['nullable', 'string', 'max:255'];
+            $rules["map.$locale.whatsapp_label"] = ['nullable', 'string', 'max:255'];
+
+            $rules["contact_forms.ads.$locale.card_text"] = ['nullable', 'string'];
+            $rules["contact_forms.ads.$locale.modal_title"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.ads.$locale.submit_text"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.ads.$locale.labels"] = ['nullable', 'array'];
+            $rules["contact_forms.ads.$locale.radio"] = ['nullable', 'array'];
+            $rules["contact_forms.ads.$locale.options"] = ['nullable', 'array'];
+
+            $rules["contact_forms.screens.$locale.card_text"] = ['nullable', 'string'];
+            $rules["contact_forms.screens.$locale.modal_title"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.screens.$locale.submit_text"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.screens.$locale.labels"] = ['nullable', 'array'];
+            $rules["contact_forms.screens.$locale.radio"] = ['nullable', 'array'];
+            $rules["contact_forms.screens.$locale.options"] = ['nullable', 'array'];
+
+            $rules["contact_forms.create.$locale.card_text"] = ['nullable', 'string'];
+            $rules["contact_forms.create.$locale.modal_title"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.create.$locale.submit_text"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.create.$locale.labels"] = ['nullable', 'array'];
+
+            $rules["contact_forms.faq.$locale.card_text"] = ['nullable', 'string'];
+            $rules["contact_forms.faq.$locale.modal_title"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.faq.$locale.submit_text"] = ['nullable', 'string', 'max:255'];
+            $rules["contact_forms.faq.$locale.labels"] = ['nullable', 'array'];
+        }
+
+        $rules['contact_forms.ads.card_image1'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.ads.card_image2'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.screens.card_image1'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.screens.card_image2'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.create.card_image1'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.create.card_image2'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.faq.card_image1'] = ['nullable', 'file', 'image', 'max:20480'];
+        $rules['contact_forms.faq.card_image2'] = ['nullable', 'file', 'image', 'max:20480'];
+
+        $validated = $request->validate($rules);
+
+        DB::transaction(function () use ($request, $banner, $contact, $map, $bottom, $ads, $screens, $create, $faq) {
+            if ($banner) {
+                $this->updateImageOnlySection($request, $banner, 'banner.image', 'cms/contact/banner');
+            }
+
+            if ($contact) {
+                $this->updateContactSection($request, $contact);
+            }
+
+            if ($map) {
+                $this->updateMapSection($request, $map);
+            }
+
+            if ($bottom) {
+                $this->updateImageOnlySection($request, $bottom, 'bottom.image', 'cms/contact/bottom');
+            }
+
+            if ($ads) {
+                $this->updateContactFormSection($request, $ads, 'ads');
+            }
+
+            if ($screens) {
+                $this->updateContactFormSection($request, $screens, 'screens');
+            }
+
+            if ($create) {
+                $this->updateContactFormSection($request, $create, 'create');
+            }
+
+            if ($faq) {
+                $this->updateContactFormSection($request, $faq, 'faq');
+            }
+        });
+
+        Cache::forget('page.contact-us');
+
+        return redirect()
+            ->route('admin.cms.contact.edit', ['lang' => $lang])
+            ->with('success', 'تم تحديث محتوى صفحة تواصل معنا بنجاح.');
+    }
+
+    protected function updateImageOnlySection(Request $request, $section, string $field, string $folder): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $existing = $data[$this->primaryLocale]['image_path'] ?? null;
+        $image = $this->upload($request, $field, $folder, $existing);
+
+        foreach ($this->locales as $locale) {
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'image_path' => $image,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function updateContactSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("contact.$locale", []);
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'title' => $payload['title'] ?? null,
+                'subtitle' => $payload['subtitle'] ?? null,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function updateMapSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $existing = $data[$this->primaryLocale]['background_image_path'] ?? null;
+        $background = $this->upload($request, 'map.background_image', 'cms/contact/map', $existing);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("map.$locale", []);
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'background_image_path' => $background,
+                'title' => $payload['title'] ?? null,
+                'address' => $payload['address'] ?? null,
+                'phone_label' => $payload['phone_label'] ?? null,
+                'whatsapp_label' => $payload['whatsapp_label'] ?? null,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function updateContactFormSection(Request $request, $section, string $key): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $basePath = "contact_forms.$key";
+
+        $image1Existing = $data[$this->primaryLocale]['card_image1'] ?? null;
+        $image2Existing = $data[$this->primaryLocale]['card_image2'] ?? null;
+
+        $image1 = $this->upload($request, "$basePath.card_image1", "cms/contact/$key", $image1Existing);
+        $image2 = $this->upload($request, "$basePath.card_image2", "cms/contact/$key", $image2Existing);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("$basePath.$locale", []);
+
+            $options = [];
+            foreach (($payload['options'] ?? []) as $optionKey => $value) {
+                $lines = preg_split("/(\r\n|\n|\r)/", (string) $value);
+                $options[$optionKey] = array_values(array_filter(array_map('trim', $lines), fn($line) => $line !== ''));
+            }
+
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'card_image1' => $image1,
+                'card_image2' => $image2,
+                'card_text' => $payload['card_text'] ?? null,
+                'modal_title' => $payload['modal_title'] ?? null,
+                'submit_text' => $payload['submit_text'] ?? null,
+                'labels' => $payload['labels'] ?? [],
+            ]);
+
+            if (array_key_exists('radio', $payload)) {
+                $data[$locale]['radio'] = $payload['radio'] ?? [];
+            }
+
+            if (!empty($options) || isset($data[$locale]['options'])) {
+                $data[$locale]['options'] = $options;
+            }
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+}

--- a/app/Http/Controllers/Admin/Cms/HomePageContentController.php
+++ b/app/Http/Controllers/Admin/Cms/HomePageContentController.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Cms;
+
+use App\Models\SectionItem;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class HomePageContentController extends BasePageContentController
+{
+    public function edit(string $lang)
+    {
+        $page = $this->loadPage('home');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('banner');
+        $partners = $sections->get('partners');
+        $about = $sections->get('about');
+        $stats = $sections->get('stats');
+        $where = $sections->get('where_us');
+        $cta = $sections->get('cta');
+
+        return view('admin.cms.home.edit', [
+            'page' => $page,
+            'locales' => $this->locales,
+            'banner' => $banner,
+            'bannerData' => $this->getSectionTranslations($banner),
+            'partners' => $partners,
+            'partnerItemData' => $this->getItemsTranslations($partners),
+            'about' => $about,
+            'aboutData' => $this->getSectionTranslations($about),
+            'stats' => $stats,
+            'statsItemData' => $this->getItemsTranslations($stats),
+            'whereUs' => $where,
+            'whereData' => $this->getSectionTranslations($where),
+            'whereItemsData' => $this->getItemsTranslations($where),
+            'cta' => $cta,
+            'ctaData' => $this->getSectionTranslations($cta),
+        ]);
+    }
+
+    public function update(string $lang, Request $request)
+    {
+        $page = $this->loadPage('home');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('banner');
+        $partners = $sections->get('partners');
+        $about = $sections->get('about');
+        $stats = $sections->get('stats');
+        $where = $sections->get('where_us');
+        $cta = $sections->get('cta');
+
+        $rules = [
+            'banner.video' => ['nullable', 'file', 'mimetypes:video/mp4', 'max:153600'],
+            'banner.autoplay' => ['nullable', 'boolean'],
+            'banner.loop' => ['nullable', 'boolean'],
+            'banner.muted' => ['nullable', 'boolean'],
+            'banner.controls' => ['nullable', 'boolean'],
+            'banner.playsinline' => ['nullable', 'boolean'],
+            'partners.items' => ['nullable', 'array'],
+            'partners.items.*.id' => ['nullable', 'integer'],
+            'partners.items.*.order' => ['nullable', 'integer', 'min:0'],
+            'partners.items.*.image' => ['nullable', 'file', 'image', 'max:10240'],
+            'partners.items.*.existing_image' => ['nullable', 'string'],
+            'about' => ['nullable', 'array'],
+            'stats.items' => ['nullable', 'array'],
+            'stats.items.*.id' => ['nullable', 'integer'],
+            'stats.items.*.order' => ['nullable', 'integer', 'min:0'],
+            'stats.items.*.icon' => ['nullable', 'file', 'image', 'max:5120'],
+            'stats.items.*.existing_icon' => ['nullable', 'string'],
+            'where_us.title' => ['nullable', 'array'],
+            'where_us.brochure_text' => ['nullable', 'array'],
+            'where_us.brochure_icon' => ['nullable', 'file', 'image', 'max:5120'],
+            'where_us.brochure_file' => ['nullable', 'file', 'mimes:pdf', 'max:20480'],
+            'where_us.brochure_link' => ['nullable', 'string', 'max:500'],
+            'where_us.items' => ['nullable', 'array'],
+            'where_us.items.*.id' => ['nullable', 'integer'],
+            'where_us.items.*.order' => ['nullable', 'integer', 'min:0'],
+            'where_us.items.*.image' => ['nullable', 'file', 'image', 'max:10240'],
+            'where_us.items.*.existing_image' => ['nullable', 'string'],
+            'cta.image' => ['nullable', 'file', 'image', 'max:10240'],
+            'cta.overlay_image' => ['nullable', 'file', 'image', 'max:10240'],
+        ];
+
+        foreach ($this->locales as $locale) {
+            $rules["about.$locale.title"] = ['nullable', 'string', 'max:255'];
+            $rules["about.$locale.desc"] = ['nullable', 'string'];
+            $rules["about.$locale.readmore_text"] = ['nullable', 'string', 'max:255'];
+            $rules["about.$locale.readmore_link"] = ['nullable', 'string', 'max:255'];
+
+            $rules["partners.items.*.alt.$locale"] = ['nullable', 'string', 'max:255'];
+
+            $rules["stats.items.*.number.$locale"] = ['nullable', 'string', 'max:255'];
+            $rules["stats.items.*.label.$locale"] = ['nullable', 'string', 'max:255'];
+
+            $rules["where_us.title.$locale"] = ['nullable', 'string', 'max:255'];
+            $rules["where_us.brochure_text.$locale"] = ['nullable', 'string', 'max:255'];
+            $rules["where_us.items.*.overlay.$locale"] = ['nullable', 'string', 'max:255'];
+
+            $rules["cta.$locale.title"] = ['nullable', 'string', 'max:255'];
+            $rules["cta.$locale.text"] = ['nullable', 'string'];
+            $rules["cta.$locale.link_text"] = ['nullable', 'string', 'max:255'];
+            $rules["cta.$locale.link_url"] = ['nullable', 'string', 'max:500'];
+        }
+
+        $validated = $request->validate($rules);
+
+        DB::transaction(function () use ($request, $banner, $partners, $about, $stats, $where, $cta) {
+            if ($banner) {
+                $this->updateBannerSection($request, $banner);
+            }
+
+            if ($partners) {
+                $this->syncPartnerItems($request, $partners);
+            }
+
+            if ($about) {
+                $this->updateAboutSection($request, $about);
+            }
+
+            if ($stats) {
+                $this->syncStatsItems($request, $stats);
+            }
+
+            if ($where) {
+                $this->updateWhereUsSection($request, $where);
+            }
+
+            if ($cta) {
+                $this->updateCtaSection($request, $cta);
+            }
+        });
+
+        Cache::forget('page.home');
+
+        return redirect()
+            ->route('admin.cms.home.edit', ['lang' => $lang])
+            ->with('success', 'تم تحديث محتوى صفحة الرئيسية بنجاح.');
+    }
+
+    protected function updateBannerSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $existingVideo = $data[$this->primaryLocale]['video_path'] ?? null;
+
+        $videoPath = $this->upload($request, 'banner.video', 'cms/home/banner', $existingVideo);
+
+        foreach ($this->locales as $locale) {
+            $current = $data[$locale] ?? [];
+
+            $data[$locale] = array_merge($current, [
+                'video_path' => $videoPath,
+                'autoplay' => $request->boolean('banner.autoplay'),
+                'loop' => $request->boolean('banner.loop'),
+                'muted' => $request->boolean('banner.muted'),
+                'controls' => $request->boolean('banner.controls'),
+                'playsinline' => $request->boolean('banner.playsinline'),
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function syncPartnerItems(Request $request, $section): void
+    {
+        $inputItems = $request->input('partners.items', []);
+        $existingCollection = $section->items;
+        $existingItems = $existingCollection->keyBy('id');
+        $existingData = $this->getItemsTranslations($section);
+
+        $persistedIds = [];
+
+        foreach ($inputItems as $index => $payload) {
+            $itemId = isset($payload['id']) ? (int) $payload['id'] : null;
+            $item = $itemId ? $existingItems->get($itemId) : new SectionItem(['section_id' => $section->id]);
+
+            $currentTranslations = $itemId && isset($existingData[$itemId])
+                ? $existingData[$itemId]
+                : array_fill_keys($this->locales, []);
+
+            $existingPath = $payload['existing_image'] ?? ($currentTranslations[$this->primaryLocale]['image_path'] ?? null);
+
+            $imagePath = $this->upload($request, "partners.items.$index.image", 'cms/home/partners', $existingPath);
+
+            if (!$itemId && !$imagePath) {
+                // Skip incomplete new items
+                continue;
+            }
+
+            $itemData = [];
+
+            foreach ($this->locales as $locale) {
+                $itemData[$locale] = array_merge($currentTranslations[$locale] ?? [], [
+                    'image_path' => $imagePath,
+                    'alt' => $payload['alt'][$locale] ?? null,
+                ]);
+            }
+
+            $item->section_id = $section->id;
+            $item->order = (int) ($payload['order'] ?? 0);
+            $item->data = $itemData;
+            $item->save();
+
+            $persistedIds[] = $item->id;
+        }
+
+        if (!empty($persistedIds)) {
+            $section->items()->whereNotIn('id', $persistedIds)->delete();
+        } elseif ($existingCollection->isNotEmpty() && empty($inputItems)) {
+            $section->items()->delete();
+        }
+    }
+
+    protected function updateAboutSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("about.$locale", []);
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'title' => $payload['title'] ?? null,
+                'desc' => $payload['desc'] ?? null,
+                'readmore_text' => $payload['readmore_text'] ?? null,
+                'readmore_link' => $payload['readmore_link'] ?? null,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function syncStatsItems(Request $request, $section): void
+    {
+        $inputItems = $request->input('stats.items', []);
+        $existingCollection = $section->items;
+        $existingItems = $existingCollection->keyBy('id');
+        $existingData = $this->getItemsTranslations($section);
+        $persistedIds = [];
+
+        foreach ($inputItems as $index => $payload) {
+            $itemId = isset($payload['id']) ? (int) $payload['id'] : null;
+            $item = $itemId ? $existingItems->get($itemId) : new SectionItem(['section_id' => $section->id]);
+            $currentTranslations = $itemId && isset($existingData[$itemId])
+                ? $existingData[$itemId]
+                : array_fill_keys($this->locales, []);
+
+            $existingIcon = $payload['existing_icon'] ?? ($currentTranslations[$this->primaryLocale]['icon_path'] ?? null);
+            $iconPath = $this->upload($request, "stats.items.$index.icon", 'cms/home/stats', $existingIcon);
+
+            if (!$itemId && !$iconPath) {
+                continue;
+            }
+
+            $itemData = [];
+            foreach ($this->locales as $locale) {
+                $itemData[$locale] = array_merge($currentTranslations[$locale] ?? [], [
+                    'icon_path' => $iconPath,
+                    'number' => $payload['number'][$locale] ?? null,
+                    'label' => $payload['label'][$locale] ?? null,
+                ]);
+            }
+
+            $item->section_id = $section->id;
+            $item->order = (int) ($payload['order'] ?? 0);
+            $item->data = $itemData;
+            $item->save();
+
+            $persistedIds[] = $item->id;
+        }
+
+        if (!empty($persistedIds)) {
+            $section->items()->whereNotIn('id', $persistedIds)->delete();
+        } elseif ($existingCollection->isNotEmpty() && empty($inputItems)) {
+            $section->items()->delete();
+        }
+    }
+
+    protected function updateWhereUsSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+
+        $existingIcon = $data[$this->primaryLocale]['brochure']['icon_path'] ?? null;
+        $iconPath = $this->upload($request, 'where_us.brochure_icon', 'cms/home/where-us', $existingIcon);
+
+        $existingBrochure = $data[$this->primaryLocale]['brochure']['brochure_path'] ?? null;
+        $brochurePath = $this->upload($request, 'where_us.brochure_file', 'cms/home/where-us', $existingBrochure);
+        $brochureLink = $request->input('where_us.brochure_link');
+
+        foreach ($this->locales as $locale) {
+            $title = $request->input("where_us.title.$locale");
+            $brochureText = $request->input("where_us.brochure_text.$locale");
+
+            $current = $data[$locale] ?? [];
+            $brochure = $current['brochure'] ?? [];
+
+            $brochure['text'] = $brochureText;
+            $brochure['icon_path'] = $iconPath;
+            $brochure['brochure_path'] = $brochurePath ?: ($brochureLink ?: ($brochure['brochure_path'] ?? null));
+
+            $data[$locale] = array_merge($current, [
+                'title' => $title,
+                'brochure' => $brochure,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+
+        $this->syncWhereUsItems($request, $section);
+    }
+
+    protected function syncWhereUsItems(Request $request, $section): void
+    {
+        $inputItems = $request->input('where_us.items', []);
+        $existingCollection = $section->items;
+        $existingItems = $existingCollection->keyBy('id');
+        $existingData = $this->getItemsTranslations($section);
+        $persistedIds = [];
+
+        foreach ($inputItems as $index => $payload) {
+            $itemId = isset($payload['id']) ? (int) $payload['id'] : null;
+            $item = $itemId ? $existingItems->get($itemId) : new SectionItem(['section_id' => $section->id]);
+            $currentTranslations = $itemId && isset($existingData[$itemId])
+                ? $existingData[$itemId]
+                : array_fill_keys($this->locales, []);
+
+            $existingImage = $payload['existing_image'] ?? ($currentTranslations[$this->primaryLocale]['image_path'] ?? null);
+            $imagePath = $this->upload($request, "where_us.items.$index.image", 'cms/home/where-us', $existingImage);
+
+            if (!$itemId && !$imagePath) {
+                continue;
+            }
+
+            $itemData = [];
+
+            foreach ($this->locales as $locale) {
+                $itemData[$locale] = array_merge($currentTranslations[$locale] ?? [], [
+                    'image_path' => $imagePath,
+                    'overlay_text' => $payload['overlay'][$locale] ?? null,
+                ]);
+            }
+
+            $item->section_id = $section->id;
+            $item->order = (int) ($payload['order'] ?? 0);
+            $item->data = $itemData;
+            $item->save();
+
+            $persistedIds[] = $item->id;
+        }
+
+        if (!empty($persistedIds)) {
+            $section->items()->whereNotIn('id', $persistedIds)->delete();
+        } elseif ($existingCollection->isNotEmpty() && empty($inputItems)) {
+            $section->items()->delete();
+        }
+    }
+
+    protected function updateCtaSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+
+        $existingImage = $data[$this->primaryLocale]['image_path'] ?? null;
+        $existingOverlay = $data[$this->primaryLocale]['overlay_image_path'] ?? null;
+
+        $imagePath = $this->upload($request, 'cta.image', 'cms/home/cta', $existingImage);
+        $overlayPath = $this->upload($request, 'cta.overlay_image', 'cms/home/cta', $existingOverlay);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("cta.$locale", []);
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'title' => $payload['title'] ?? null,
+                'text' => $payload['text'] ?? null,
+                'link_text' => $payload['link_text'] ?? null,
+                'link_url' => $payload['link_url'] ?? null,
+                'image_path' => $imagePath,
+                'overlay_image_path' => $overlayPath,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+}

--- a/app/Http/Controllers/Admin/Cms/WhoWeArePageContentController.php
+++ b/app/Http/Controllers/Admin/Cms/WhoWeArePageContentController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Cms;
+
+use App\Models\SectionItem;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class WhoWeArePageContentController extends BasePageContentController
+{
+    public function edit(string $lang)
+    {
+        $page = $this->loadPage('whoweare');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('second_banner');
+        $whoWe = $sections->get('who_we');
+        $port = $sections->get('port_image');
+
+        return view('admin.cms.whoweare.edit', [
+            'page' => $page,
+            'locales' => $this->locales,
+            'banner' => $banner,
+            'bannerData' => $this->getSectionTranslations($banner),
+            'whoWe' => $whoWe,
+            'whoWeData' => $this->getSectionTranslations($whoWe),
+            'whoWeItems' => $this->getItemsTranslations($whoWe),
+            'port' => $port,
+            'portData' => $this->getSectionTranslations($port),
+        ]);
+    }
+
+    public function update(string $lang, Request $request)
+    {
+        $page = $this->loadPage('whoweare');
+        $sections = $page->sections->keyBy('type');
+
+        $banner = $sections->get('second_banner');
+        $whoWe = $sections->get('who_we');
+        $port = $sections->get('port_image');
+
+        $rules = [
+            'banner.image' => ['nullable', 'file', 'image', 'max:15360'],
+            'who_we.items' => ['nullable', 'array'],
+            'who_we.items.*.id' => ['nullable', 'integer'],
+            'who_we.items.*.order' => ['nullable', 'integer', 'min:0'],
+            'port.image' => ['nullable', 'file', 'image', 'max:15360'],
+        ];
+
+        foreach ($this->locales as $locale) {
+            $rules["who_we.$locale.title"] = ['nullable', 'string', 'max:255'];
+            $rules["who_we.$locale.description"] = ['nullable', 'string'];
+
+            $rules["who_we.items.*.title.$locale"] = ['nullable', 'string', 'max:255'];
+            $rules["who_we.items.*.text.$locale"] = ['nullable', 'string'];
+            $rules["who_we.items.*.bullets.$locale"] = ['nullable', 'string'];
+        }
+
+        $validated = $request->validate($rules);
+
+        DB::transaction(function () use ($request, $banner, $whoWe, $port) {
+            if ($banner) {
+                $this->updateBanner($request, $banner);
+            }
+
+            if ($whoWe) {
+                $this->updateWhoWeSection($request, $whoWe);
+            }
+
+            if ($port) {
+                $this->updatePortSection($request, $port);
+            }
+        });
+
+        Cache::forget('page.whoweare');
+
+        return redirect()
+            ->route('admin.cms.whoweare.edit', ['lang' => $lang])
+            ->with('success', 'تم تحديث محتوى صفحة من نحن بنجاح.');
+    }
+
+    protected function updateBanner(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $existingImage = $data[$this->primaryLocale]['image_path'] ?? null;
+
+        $imagePath = $this->upload($request, 'banner.image', 'cms/whoweare/banner', $existingImage);
+
+        foreach ($this->locales as $locale) {
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'image_path' => $imagePath,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+
+    protected function updateWhoWeSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+
+        foreach ($this->locales as $locale) {
+            $payload = $request->input("who_we.$locale", []);
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'title' => $payload['title'] ?? null,
+                'description' => $payload['description'] ?? null,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+
+        $this->syncWhoWeItems($request, $section);
+    }
+
+    protected function syncWhoWeItems(Request $request, $section): void
+    {
+        $inputItems = $request->input('who_we.items', []);
+        $existingCollection = $section->items;
+        $existingItems = $existingCollection->keyBy('id');
+        $existingData = $this->getItemsTranslations($section);
+        $persistedIds = [];
+
+        foreach ($inputItems as $payload) {
+            $itemId = isset($payload['id']) ? (int) $payload['id'] : null;
+            $item = $itemId ? $existingItems->get($itemId) : new SectionItem(['section_id' => $section->id]);
+            $currentTranslations = $itemId && isset($existingData[$itemId])
+                ? $existingData[$itemId]
+                : array_fill_keys($this->locales, []);
+
+            $itemData = [];
+
+            foreach ($this->locales as $locale) {
+                $bulletsRaw = $payload['bullets'][$locale] ?? '';
+                $lines = preg_split("/(\r\n|\n|\r)/", (string) $bulletsRaw);
+                $bullets = array_values(array_filter(array_map('trim', $lines), fn($line) => $line !== ''));
+
+                $itemData[$locale] = array_merge($currentTranslations[$locale] ?? [], [
+                    'title' => $payload['title'][$locale] ?? null,
+                    'text' => $payload['text'][$locale] ?? null,
+                    'bullets' => $bullets,
+                ]);
+            }
+
+            $item->section_id = $section->id;
+            $item->order = (int) ($payload['order'] ?? 0);
+            $item->data = $itemData;
+            $item->save();
+
+            $persistedIds[] = $item->id;
+        }
+
+        if (!empty($persistedIds)) {
+            $section->items()->whereNotIn('id', $persistedIds)->delete();
+        } elseif ($existingCollection->isNotEmpty() && empty($inputItems)) {
+            $section->items()->delete();
+        }
+    }
+
+    protected function updatePortSection(Request $request, $section): void
+    {
+        $data = $this->getSectionTranslations($section);
+        $existingImage = $data[$this->primaryLocale]['image_path'] ?? null;
+
+        $imagePath = $this->upload($request, 'port.image', 'cms/whoweare/port', $existingImage);
+
+        foreach ($this->locales as $locale) {
+            $data[$locale] = array_merge($data[$locale] ?? [], [
+                'image_path' => $imagePath,
+            ]);
+        }
+
+        $section->section_data = $data;
+        $section->save();
+    }
+}

--- a/app/Services/FileService.php
+++ b/app/Services/FileService.php
@@ -113,4 +113,47 @@ class FileService implements FileServiceInterface
             }
         }
     }
+
+    public function uploadSingle(Request $request, string $field, string $baseFolder, ?string $existing = null): ?string
+    {
+        if (!$request->hasFile($field)) {
+            return $existing;
+        }
+
+        $folder = $this->buildModelFolder($baseFolder);
+        $existingFile = $existing ? basename($existing) : null;
+
+        $stub = new class($existingFile) extends Model {
+            protected $table = 'file_service_stub';
+            public $timestamps = false;
+            protected $fillable = ['path'];
+
+            public function __construct(?string $existing)
+            {
+                parent::__construct();
+                if ($existing) {
+                    $this->setAttribute('path', $existing);
+                }
+            }
+
+            public function save(array $options = [])
+            {
+                return true;
+            }
+        };
+
+        $uploaded = $this->uploadFile([
+            $request->file($field)
+        ], [
+            $folder
+        ], [
+            'path'
+        ], $stub);
+
+        if (!empty($uploaded[0])) {
+            return trim($baseFolder, '/') . '/' . $uploaded[0];
+        }
+
+        return $existing;
+    }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -13,6 +13,7 @@ if (! function_exists('media_path')) {
             'http://', 'https://',
             '/storage', 'storage/',
             '/frontend/', 'frontend/',
+            '/cms/', 'cms/',
         ])) {
             return ltrim($path, '/');
         }

--- a/resources/views/admin/cms/contact-us/edit.blade.php
+++ b/resources/views/admin/cms/contact-us/edit.blade.php
@@ -1,0 +1,217 @@
+@extends('admin.layouts.master')
+@section('content')
+    @php
+        $primaryLocale = config('app.locale');
+    @endphp
+    <div class="page-wrapper">
+        @include('admin.layouts.sidebar')
+        <div class="page-content">
+            @include('admin.layouts.page-header', ['pageName' => $page->name])
+            <div class="main-container">
+                @include('admin.layouts.alerts')
+                <form method="POST" action="{{ route('admin.cms.contact.update', ['lang' => app()->getLocale()]) }}" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Top Banner</h5>
+                        </div>
+                        <div class="card-body">
+                            @include('admin.layouts.components.media-upload', [
+                                'label' => 'Banner Image',
+                                'name' => 'banner[image]',
+                                'inputId' => 'contact_banner_image',
+                                'previewPath' => media_path($bannerData[$primaryLocale]['image_path'] ?? ''),
+                            ])
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Contact Heading</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="contact[{{ $locale }}][title]"
+                                            value="{{ old("contact.$locale.title", $contactData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Subtitle ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="contact[{{ $locale }}][subtitle]"
+                                            value="{{ old("contact.$locale.subtitle", $contactData[$locale]['subtitle'] ?? '') }}">
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Map & Location</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    @include('admin.layouts.components.media-upload', [
+                                        'label' => 'Background Image',
+                                        'name' => 'map[background_image]',
+                                        'inputId' => 'contact_map_background',
+                                        'previewPath' => media_path($mapData[$primaryLocale]['background_image_path'] ?? ''),
+                                    ])
+                                </div>
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="map[{{ $locale }}][title]"
+                                            value="{{ old("map.$locale.title", $mapData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label">Address ({{ strtoupper($locale) }})</label>
+                                        <textarea class="form-control" rows="3" name="map[{{ $locale }}][address]">{{ old("map.$locale.address", $mapData[$locale]['address'] ?? '') }}</textarea>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Phone label ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="map[{{ $locale }}][phone_label]"
+                                            value="{{ old("map.$locale.phone_label", $mapData[$locale]['phone_label'] ?? '') }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">WhatsApp label ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="map[{{ $locale }}][whatsapp_label]"
+                                            value="{{ old("map.$locale.whatsapp_label", $mapData[$locale]['whatsapp_label'] ?? '') }}">
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Bottom Banner</h5>
+                        </div>
+                        <div class="card-body">
+                            @include('admin.layouts.components.media-upload', [
+                                'label' => 'Banner Image',
+                                'name' => 'bottom[image]',
+                                'inputId' => 'contact_bottom_image',
+                                'previewPath' => media_path($bottomData[$primaryLocale]['image_path'] ?? ''),
+                            ])
+                        </div>
+                    </div>
+
+                    @php
+                        $forms = [
+                            'ads' => ['title' => 'Ads Subscription Form', 'data' => $adsData, 'form' => $adsForm],
+                            'screens' => ['title' => 'Screens Subscription Form', 'data' => $screensData, 'form' => $screensForm],
+                            'create' => ['title' => 'Ad Creation Request', 'data' => $createData, 'form' => $createForm],
+                            'faq' => ['title' => 'FAQs Form', 'data' => $faqData, 'form' => $faqForm],
+                        ];
+                    @endphp
+
+                    @foreach ($forms as $key => $payload)
+                        @php $sectionData = $payload['data']; @endphp
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <h5 class="mb-0">{{ $payload['title'] }}</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        @include('admin.layouts.components.media-upload', [
+                                            'label' => 'Card Image 1',
+                                            'name' => "contact_forms[$key][card_image1]",
+                                            'inputId' => "contact_{$key}_image1",
+                                            'previewPath' => media_path($sectionData[$primaryLocale]['card_image1'] ?? ''),
+                                        ])
+                                    </div>
+                                    <div class="col-md-6">
+                                        @include('admin.layouts.components.media-upload', [
+                                            'label' => 'Card Image 2',
+                                            'name' => "contact_forms[$key][card_image2]",
+                                            'inputId' => "contact_{$key}_image2",
+                                            'previewPath' => media_path($sectionData[$primaryLocale]['card_image2'] ?? ''),
+                                        ])
+                                    </div>
+                                </div>
+                                <div class="row g-3 mt-0">
+                                    @foreach ($locales as $locale)
+                                        <div class="col-md-6">
+                                            <label class="form-label">Card Text ({{ strtoupper($locale) }})</label>
+                                            <textarea class="form-control" rows="3" name="contact_forms[{{ $key }}][{{ $locale }}][card_text]">{{ old("contact_forms.$key.$locale.card_text", $sectionData[$locale]['card_text'] ?? '') }}</textarea>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Modal Title ({{ strtoupper($locale) }})</label>
+                                            <input type="text" class="form-control" name="contact_forms[{{ $key }}][{{ $locale }}][modal_title]"
+                                                value="{{ old("contact_forms.$key.$locale.modal_title", $sectionData[$locale]['modal_title'] ?? '') }}">
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label class="form-label">Submit Text ({{ strtoupper($locale) }})</label>
+                                            <input type="text" class="form-control" name="contact_forms[{{ $key }}][{{ $locale }}][submit_text]"
+                                                value="{{ old("contact_forms.$key.$locale.submit_text", $sectionData[$locale]['submit_text'] ?? '') }}">
+                                        </div>
+
+                                        @php
+                                            $labels = $sectionData[$locale]['labels'] ?? [];
+                                        @endphp
+                                        @if (!empty($labels))
+                                            <div class="col-12">
+                                                <div class="row g-3">
+                                                    @foreach ($labels as $labelKey => $labelValue)
+                                                        <div class="col-md-6">
+                                                            <label class="form-label">Label {{ strtoupper($locale) }} - {{ \Illuminate\Support\Str::headline($labelKey) }}</label>
+                                                            <input type="text" class="form-control"
+                                                                name="contact_forms[{{ $key }}][{{ $locale }}][labels][{{ $labelKey }}]"
+                                                                value="{{ old("contact_forms.$key.$locale.labels.$labelKey", $labelValue) }}">
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        @endif
+
+                                        @php $radio = $sectionData[$locale]['radio'] ?? []; @endphp
+                                        @if (!empty($radio))
+                                            <div class="col-12">
+                                                <div class="row g-3">
+                                                    @foreach ($radio as $radioKey => $radioValue)
+                                                        <div class="col-md-6">
+                                                            <label class="form-label">Radio {{ strtoupper($locale) }} - {{ \Illuminate\Support\Str::headline($radioKey) }}</label>
+                                                            <input type="text" class="form-control"
+                                                                name="contact_forms[{{ $key }}][{{ $locale }}][radio][{{ $radioKey }}]"
+                                                                value="{{ old("contact_forms.$key.$locale.radio.$radioKey", $radioValue) }}">
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        @endif
+
+                                        @php $options = $sectionData[$locale]['options'] ?? []; @endphp
+                                        @if (!empty($options))
+                                            <div class="col-12">
+                                                <div class="row g-3">
+                                                    @foreach ($options as $optionKey => $optionValues)
+                                                        <div class="col-md-6">
+                                                            <label class="form-label">Options {{ strtoupper($locale) }} - {{ \Illuminate\Support\Str::headline($optionKey) }}</label>
+                                                            <textarea class="form-control" rows="3" name="contact_forms[{{ $key }}][{{ $locale }}][options][{{ $optionKey }}]">{{ old("contact_forms.$key.$locale.options.$optionKey", implode("\n", $optionValues ?? [])) }}</textarea>
+                                                            <small class="text-muted">Enter each option on a separate line.</small>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        @endif
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary">{{ __('admin.forms.save_button') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/cms/home/edit.blade.php
+++ b/resources/views/admin/cms/home/edit.blade.php
@@ -1,0 +1,473 @@
+@extends('admin.layouts.master')
+@section('content')
+    @php
+        $primaryLocale = config('app.locale');
+    @endphp
+    <div class="page-wrapper">
+        @include('admin.layouts.sidebar')
+        <div class="page-content">
+            @include('admin.layouts.page-header', ['pageName' => $page->name])
+            <div class="main-container">
+                @include('admin.layouts.alerts')
+                <form method="POST" action="{{ route('admin.cms.home.update', ['lang' => app()->getLocale()]) }}" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+
+                    <div class="card mb-4">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">{{ __('admin.sidebar.home_page') }} - Banner</h5>
+                        </div>
+                        <div class="card-body">
+                            @include('admin.layouts.components.media-upload', [
+                                'label' => 'Video',
+                                'name' => 'banner[video]',
+                                'inputId' => 'home_banner_video',
+                                'acceptedTypes' => 'video/mp4',
+                                'previewPath' => media_path($bannerData[$primaryLocale]['video_path'] ?? ''),
+                            ])
+                            <div class="row g-3 mt-0">
+                                @foreach (['autoplay', 'loop', 'muted', 'controls', 'playsinline'] as $flag)
+                                    <div class="col-md-4">
+                                        <div class="form-check mt-3">
+                                            <input type="hidden" name="banner[{{ $flag }}]" value="0">
+                                            <input type="checkbox" class="form-check-input" id="banner_{{ $flag }}"
+                                                name="banner[{{ $flag }}]"
+                                                value="1" @checked(old("banner.$flag", $bannerData[$primaryLocale][$flag] ?? false))>
+                                            <label class="form-check-label" for="banner_{{ $flag }}">{{ ucfirst($flag) }}</label>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4" id="partners-section">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">Partners Slider</h5>
+                            <button type="button" class="btn btn-sm btn-primary" id="add-partner-item">{{ __('admin.buttons.new') }}</button>
+                        </div>
+                        <div class="card-body" id="partner-items-container">
+                            @php $partnerIndex = 0; @endphp
+                            @foreach ($partners?->items ?? [] as $item)
+                                @php
+                                    $itemData = $partnerItemData[$item->id] ?? [];
+                                    $currentPath = $itemData[$primaryLocale]['image_path'] ?? '';
+                                @endphp
+                                <div class="card mb-3 partner-item" data-index="{{ $partnerIndex }}">
+                                    <div class="card-header d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <strong>#{{ $item->id }}</strong>
+                                        </div>
+                                        <button type="button" class="btn btn-sm btn-outline-danger remove-partner-item">&times;</button>
+                                    </div>
+                                    <div class="card-body">
+                                        <input type="hidden" name="partners[items][{{ $partnerIndex }}][id]" value="{{ $item->id }}">
+                                        <input type="hidden" name="partners[items][{{ $partnerIndex }}][existing_image]" value="{{ $currentPath }}">
+                                        <div class="row g-3">
+                                            <div class="col-md-3">
+                                                <label class="form-label">Order</label>
+                                                <input type="number" name="partners[items][{{ $partnerIndex }}][order]" class="form-control"
+                                                    value="{{ old("partners.items.$partnerIndex.order", $item->order) }}">
+                                            </div>
+                                            <div class="col-md-9">
+                                                @include('admin.layouts.components.media-upload', [
+                                                    'label' => 'Slide Image',
+                                                    'name' => "partners[items][$partnerIndex][image]",
+                                                    'inputId' => "partners_item_{$partnerIndex}_image",
+                                                    'previewPath' => media_path($currentPath),
+                                                ])
+                                            </div>
+                                            @foreach ($locales as $locale)
+                                                <div class="col-md-6">
+                                                    <label class="form-label">Alt ({{ strtoupper($locale) }})</label>
+                                                    <input type="text" class="form-control"
+                                                        name="partners[items][{{ $partnerIndex }}][alt][{{ $locale }}]"
+                                                        value="{{ old("partners.items.$partnerIndex.alt.$locale", $itemData[$locale]['alt'] ?? '') }}">
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                </div>
+                                @php $partnerIndex++; @endphp
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">About Section</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="about[{{ $locale }}][title]"
+                                            value="{{ old("about.$locale.title", $aboutData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label">Description ({{ strtoupper($locale) }})</label>
+                                        <textarea class="form-control" rows="3" name="about[{{ $locale }}][desc]">{{ old("about.$locale.desc", $aboutData[$locale]['desc'] ?? '') }}</textarea>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Read more text ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="about[{{ $locale }}][readmore_text]"
+                                            value="{{ old("about.$locale.readmore_text", $aboutData[$locale]['readmore_text'] ?? '') }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Read more link ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="about[{{ $locale }}][readmore_link]"
+                                            value="{{ old("about.$locale.readmore_link", $aboutData[$locale]['readmore_link'] ?? '') }}">
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4" id="stats-section">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">Impact Metrics</h5>
+                            <button type="button" class="btn btn-sm btn-primary" id="add-stat-item">{{ __('admin.buttons.new') }}</button>
+                        </div>
+                        <div class="card-body" id="stats-items-container">
+                            @php $statsIndex = 0; @endphp
+                            @foreach ($stats?->items ?? [] as $item)
+                                @php
+                                    $itemData = $statsItemData[$item->id] ?? [];
+                                    $currentIcon = $itemData[$primaryLocale]['icon_path'] ?? '';
+                                @endphp
+                                <div class="card mb-3 stat-item" data-index="{{ $statsIndex }}">
+                                    <div class="card-header d-flex justify-content-between align-items-center">
+                                        <strong>#{{ $item->id }}</strong>
+                                        <button type="button" class="btn btn-sm btn-outline-danger remove-stat-item">&times;</button>
+                                    </div>
+                                    <div class="card-body">
+                                        <input type="hidden" name="stats[items][{{ $statsIndex }}][id]" value="{{ $item->id }}">
+                                        <input type="hidden" name="stats[items][{{ $statsIndex }}][existing_icon]" value="{{ $currentIcon }}">
+                                        <div class="row g-3">
+                                            <div class="col-md-3">
+                                                <label class="form-label">Order</label>
+                                                <input type="number" name="stats[items][{{ $statsIndex }}][order]" class="form-control"
+                                                    value="{{ old("stats.items.$statsIndex.order", $item->order) }}">
+                                            </div>
+                                            <div class="col-md-9">
+                                                @include('admin.layouts.components.media-upload', [
+                                                    'label' => 'Icon',
+                                                    'name' => "stats[items][$statsIndex][icon]",
+                                                    'inputId' => "stats_item_{$statsIndex}_icon",
+                                                    'previewPath' => media_path($currentIcon),
+                                                ])
+                                            </div>
+                                            @foreach ($locales as $locale)
+                                                <div class="col-md-6">
+                                                    <label class="form-label">Number ({{ strtoupper($locale) }})</label>
+                                                    <input type="text" class="form-control"
+                                                        name="stats[items][{{ $statsIndex }}][number][{{ $locale }}]"
+                                                        value="{{ old("stats.items.$statsIndex.number.$locale", $itemData[$locale]['number'] ?? '') }}">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label class="form-label">Label ({{ strtoupper($locale) }})</label>
+                                                    <input type="text" class="form-control"
+                                                        name="stats[items][{{ $statsIndex }}][label][{{ $locale }}]"
+                                                        value="{{ old("stats.items.$statsIndex.label.$locale", $itemData[$locale]['label'] ?? '') }}">
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                </div>
+                                @php $statsIndex++; @endphp
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div class="card mb-4" id="where-section">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">Where To Find Us</h5>
+                            <button type="button" class="btn btn-sm btn-primary" id="add-where-item">{{ __('admin.buttons.new') }}</button>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="where_us[title][{{ $locale }}]"
+                                            value="{{ old("where_us.title.$locale", $whereData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Brochure text ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="where_us[brochure_text][{{ $locale }}]"
+                                            value="{{ old("where_us.brochure_text.$locale", $whereData[$locale]['brochure']['text'] ?? '') }}">
+                                    </div>
+                                @endforeach
+                                <div class="col-md-6">
+                                    @include('admin.layouts.components.media-upload', [
+                                        'label' => 'Brochure Icon',
+                                        'name' => 'where_us[brochure_icon]',
+                                        'inputId' => 'where_brochure_icon',
+                                        'previewPath' => media_path($whereData[$primaryLocale]['brochure']['icon_path'] ?? ''),
+                                    ])
+                                </div>
+                                <div class="col-md-6">
+                                    @include('admin.layouts.components.media-upload', [
+                                        'label' => 'Brochure File (PDF)',
+                                        'name' => 'where_us[brochure_file]',
+                                        'inputId' => 'where_brochure_file',
+                                        'acceptedTypes' => 'application/pdf',
+                                        'previewPath' => media_path($whereData[$primaryLocale]['brochure']['brochure_path'] ?? ''),
+                                    ])
+                                    <label class="form-label mt-2">Brochure external link</label>
+                                    <input type="text" class="form-control" name="where_us[brochure_link]"
+                                        value="{{ old('where_us.brochure_link', $whereData[$primaryLocale]['brochure']['brochure_path'] ?? '') }}">
+                                </div>
+                            </div>
+                            <hr>
+                            <div id="where-items-container">
+                                @php $whereIndex = 0; @endphp
+                                @foreach ($whereUs?->items ?? [] as $item)
+                                    @php
+                                        $itemData = $whereItemsData[$item->id] ?? [];
+                                        $currentImage = $itemData[$primaryLocale]['image_path'] ?? '';
+                                    @endphp
+                                    <div class="card mb-3 where-item" data-index="{{ $whereIndex }}">
+                                        <div class="card-header d-flex justify-content-between align-items-center">
+                                            <strong>#{{ $item->id }}</strong>
+                                            <button type="button" class="btn btn-sm btn-outline-danger remove-where-item">&times;</button>
+                                        </div>
+                                        <div class="card-body">
+                                            <input type="hidden" name="where_us[items][{{ $whereIndex }}][id]" value="{{ $item->id }}">
+                                            <input type="hidden" name="where_us[items][{{ $whereIndex }}][existing_image]" value="{{ $currentImage }}">
+                                            <div class="row g-3">
+                                                <div class="col-md-3">
+                                                    <label class="form-label">Order</label>
+                                                    <input type="number" class="form-control" name="where_us[items][{{ $whereIndex }}][order]"
+                                                        value="{{ old("where_us.items.$whereIndex.order", $item->order) }}">
+                                                </div>
+                                                <div class="col-md-9">
+                                                    @include('admin.layouts.components.media-upload', [
+                                                        'label' => 'Image',
+                                                        'name' => "where_us[items][$whereIndex][image]",
+                                                        'inputId' => "where_item_{$whereIndex}_image",
+                                                        'previewPath' => media_path($currentImage),
+                                                    ])
+                                                </div>
+                                                @foreach ($locales as $locale)
+                                                    <div class="col-md-6">
+                                                        <label class="form-label">Overlay text ({{ strtoupper($locale) }})</label>
+                                                        <input type="text" class="form-control"
+                                                            name="where_us[items][{{ $whereIndex }}][overlay][{{ $locale }}]"
+                                                            value="{{ old("where_us.items.$whereIndex.overlay.$locale", $itemData[$locale]['overlay_text'] ?? '') }}">
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    </div>
+                                    @php $whereIndex++; @endphp
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">CTA Section</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    @include('admin.layouts.components.media-upload', [
+                                        'label' => 'Main Image',
+                                        'name' => 'cta[image]',
+                                        'inputId' => 'cta_image',
+                                        'previewPath' => media_path($ctaData[$primaryLocale]['image_path'] ?? ''),
+                                    ])
+                                </div>
+                                <div class="col-md-6">
+                                    @include('admin.layouts.components.media-upload', [
+                                        'label' => 'Overlay Image',
+                                        'name' => 'cta[overlay_image]',
+                                        'inputId' => 'cta_overlay_image',
+                                        'previewPath' => media_path($ctaData[$primaryLocale]['overlay_image_path'] ?? ''),
+                                    ])
+                                </div>
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="cta[{{ $locale }}][title]"
+                                            value="{{ old("cta.$locale.title", $ctaData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label">Text ({{ strtoupper($locale) }})</label>
+                                        <textarea class="form-control" rows="3" name="cta[{{ $locale }}][text]">{{ old("cta.$locale.text", $ctaData[$locale]['text'] ?? '') }}</textarea>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Link Text ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="cta[{{ $locale }}][link_text]"
+                                            value="{{ old("cta.$locale.link_text", $ctaData[$locale]['link_text'] ?? '') }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">Link URL ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="cta[{{ $locale }}][link_url]"
+                                            value="{{ old("cta.$locale.link_url", $ctaData[$locale]['link_url'] ?? '') }}">
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary">{{ __('admin.forms.save_button') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('custom-js-scripts')
+    <template id="partner-item-template">
+        <div class="card mb-3 partner-item" data-index="__INDEX__">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>New</strong>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-partner-item">&times;</button>
+            </div>
+            <div class="card-body">
+                <input type="hidden" name="partners[items][__INDEX__][existing_image]">
+                <div class="row g-3">
+                    <div class="col-md-3">
+                        <label class="form-label">Order</label>
+                        <input type="number" name="partners[items][__INDEX__][order]" class="form-control">
+                    </div>
+                    <div class="col-md-9">
+                        @include('admin.layouts.components.media-upload', [
+                            'label' => 'Slide Image',
+                            'name' => 'partners[items][__INDEX__][image]',
+                            'inputId' => 'partners_item___INDEX___image',
+                        ])
+                    </div>
+                    @foreach ($locales as $locale)
+                        <div class="col-md-6">
+                            <label class="form-label">Alt ({{ strtoupper($locale) }})</label>
+                            <input type="text" class="form-control" name="partners[items][__INDEX__][alt][{{ $locale }}]">
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </template>
+    <template id="stat-item-template">
+        <div class="card mb-3 stat-item" data-index="__INDEX__">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>New</strong>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-stat-item">&times;</button>
+            </div>
+            <div class="card-body">
+                <input type="hidden" name="stats[items][__INDEX__][existing_icon]">
+                <div class="row g-3">
+                    <div class="col-md-3">
+                        <label class="form-label">Order</label>
+                        <input type="number" name="stats[items][__INDEX__][order]" class="form-control">
+                    </div>
+                    <div class="col-md-9">
+                        @include('admin.layouts.components.media-upload', [
+                            'label' => 'Icon',
+                            'name' => 'stats[items][__INDEX__][icon]',
+                            'inputId' => 'stats_item___INDEX___icon',
+                        ])
+                    </div>
+                    @foreach ($locales as $locale)
+                        <div class="col-md-6">
+                            <label class="form-label">Number ({{ strtoupper($locale) }})</label>
+                            <input type="text" class="form-control" name="stats[items][__INDEX__][number][{{ $locale }}]">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Label ({{ strtoupper($locale) }})</label>
+                            <input type="text" class="form-control" name="stats[items][__INDEX__][label][{{ $locale }}]">
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </template>
+    <template id="where-item-template">
+        <div class="card mb-3 where-item" data-index="__INDEX__">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>New</strong>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-where-item">&times;</button>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-3">
+                        <label class="form-label">Order</label>
+                        <input type="number" name="where_us[items][__INDEX__][order]" class="form-control">
+                    </div>
+                    <div class="col-md-9">
+                        @include('admin.layouts.components.media-upload', [
+                            'label' => 'Image',
+                            'name' => 'where_us[items][__INDEX__][image]',
+                            'inputId' => 'where_item___INDEX___image',
+                        ])
+                    </div>
+                    @foreach ($locales as $locale)
+                        <div class="col-md-6">
+                            <label class="form-label">Overlay text ({{ strtoupper($locale) }})</label>
+                            <input type="text" class="form-control" name="where_us[items][__INDEX__][overlay][{{ $locale }}]">
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </template>
+    <script>
+        function initializeDynamicUpload(container) {
+            container.querySelectorAll('[data-media-upload]').forEach(function (input) {
+                window.registerMediaUpload(input.getAttribute('id'));
+            });
+        }
+
+        function addItem(buttonId, templateId, containerId) {
+            const button = document.getElementById(buttonId);
+            const template = document.getElementById(templateId);
+            const container = document.getElementById(containerId);
+
+            if (!button || !template || !container) {
+                return;
+            }
+
+            button.addEventListener('click', function () {
+                const index = Date.now();
+                let html = template.innerHTML.replace(/__INDEX__/g, index);
+                const wrapper = document.createElement('div');
+                wrapper.innerHTML = html.trim();
+                const element = wrapper.firstElementChild;
+                container.appendChild(element);
+                initializeDynamicUpload(element);
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+            addItem('add-partner-item', 'partner-item-template', 'partner-items-container');
+            addItem('add-stat-item', 'stat-item-template', 'stats-items-container');
+            addItem('add-where-item', 'where-item-template', 'where-items-container');
+
+            document.getElementById('partner-items-container').addEventListener('click', function (event) {
+                if (event.target.classList.contains('remove-partner-item')) {
+                    event.target.closest('.partner-item').remove();
+                }
+            });
+
+            document.getElementById('stats-items-container').addEventListener('click', function (event) {
+                if (event.target.classList.contains('remove-stat-item')) {
+                    event.target.closest('.stat-item').remove();
+                }
+            });
+
+            document.getElementById('where-items-container').addEventListener('click', function (event) {
+                if (event.target.classList.contains('remove-where-item')) {
+                    event.target.closest('.where-item').remove();
+                }
+            });
+
+            document.querySelectorAll('.partner-item, .stat-item, .where-item').forEach(initializeDynamicUpload);
+        });
+    </script>
+@endpush

--- a/resources/views/admin/cms/whoweare/edit.blade.php
+++ b/resources/views/admin/cms/whoweare/edit.blade.php
@@ -1,0 +1,169 @@
+@extends('admin.layouts.master')
+@section('content')
+    @php
+        $primaryLocale = config('app.locale');
+    @endphp
+    <div class="page-wrapper">
+        @include('admin.layouts.sidebar')
+        <div class="page-content">
+            @include('admin.layouts.page-header', ['pageName' => $page->name])
+            <div class="main-container">
+                @include('admin.layouts.alerts')
+                <form method="POST" action="{{ route('admin.cms.whoweare.update', ['lang' => app()->getLocale()]) }}" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Second Banner</h5>
+                        </div>
+                        <div class="card-body">
+                            @include('admin.layouts.components.media-upload', [
+                                'label' => 'Banner Image',
+                                'name' => 'banner[image]',
+                                'inputId' => 'whoweare_banner_image',
+                                'previewPath' => media_path($bannerData[$primaryLocale]['image_path'] ?? ''),
+                            ])
+                        </div>
+                    </div>
+
+                    <div class="card mb-4" id="who-we-section">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">Who We Section</h5>
+                            <button type="button" class="btn btn-sm btn-primary" id="add-who-item">{{ __('admin.buttons.new') }}</button>
+                        </div>
+                        <div class="card-body">
+                            <div class="row g-3">
+                                @foreach ($locales as $locale)
+                                    <div class="col-md-6">
+                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                        <input type="text" class="form-control" name="who_we[{{ $locale }}][title]"
+                                            value="{{ old("who_we.$locale.title", $whoWeData[$locale]['title'] ?? '') }}">
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label">Description ({{ strtoupper($locale) }})</label>
+                                        <textarea class="form-control" rows="4" name="who_we[{{ $locale }}][description]">{{ old("who_we.$locale.description", $whoWeData[$locale]['description'] ?? '') }}</textarea>
+                                    </div>
+                                @endforeach
+                            </div>
+                            <hr>
+                            <div id="who-items-container">
+                                @php $whoIndex = 0; @endphp
+                                @foreach ($whoWe?->items ?? [] as $item)
+                                    @php $itemData = $whoWeItems[$item->id] ?? []; @endphp
+                                    <div class="card mb-3 who-item" data-index="{{ $whoIndex }}">
+                                        <div class="card-header d-flex justify-content-between align-items-center">
+                                        <strong>#{{ $item->id }}</strong>
+                                        <button type="button" class="btn btn-sm btn-outline-danger remove-who-item">&times;</button>
+                                        </div>
+                                        <div class="card-body">
+                                            <input type="hidden" name="who_we[items][{{ $whoIndex }}][id]" value="{{ $item->id }}">
+                                            <div class="row g-3">
+                                                <div class="col-md-3">
+                                                    <label class="form-label">Order</label>
+                                                    <input type="number" class="form-control" name="who_we[items][{{ $whoIndex }}][order]"
+                                                        value="{{ old("who_we.items.$whoIndex.order", $item->order) }}">
+                                                </div>
+                                                @foreach ($locales as $locale)
+                                                    <div class="col-md-6">
+                                                        <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                                                        <input type="text" class="form-control" name="who_we[items][{{ $whoIndex }}][title][{{ $locale }}]"
+                                                            value="{{ old("who_we.items.$whoIndex.title.$locale", $itemData[$locale]['title'] ?? '') }}">
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <label class="form-label">Text ({{ strtoupper($locale) }})</label>
+                                                        <textarea class="form-control" rows="3" name="who_we[items][{{ $whoIndex }}][text][{{ $locale }}]">{{ old("who_we.items.$whoIndex.text.$locale", $itemData[$locale]['text'] ?? '') }}</textarea>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label">Bullets ({{ strtoupper($locale) }})</label>
+                                                        <textarea class="form-control" rows="3" name="who_we[items][{{ $whoIndex }}][bullets][{{ $locale }}]">{{ old("who_we.items.$whoIndex.bullets.$locale", isset($itemData[$locale]['bullets']) ? implode("\n", $itemData[$locale]['bullets']) : '') }}</textarea>
+                                                        <small class="text-muted">Enter each bullet on a new line.</small>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    </div>
+                                    @php $whoIndex++; @endphp
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Portfolio Image</h5>
+                        </div>
+                        <div class="card-body">
+                            @include('admin.layouts.components.media-upload', [
+                                'label' => 'Image',
+                                'name' => 'port[image]',
+                                'inputId' => 'whoweare_port_image',
+                                'previewPath' => media_path($portData[$primaryLocale]['image_path'] ?? ''),
+                            ])
+                        </div>
+                    </div>
+
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary">{{ __('admin.forms.save_button') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('custom-js-scripts')
+    <template id="who-item-template">
+        <div class="card mb-3 who-item" data-index="__INDEX__">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>New</strong>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-who-item">&times;</button>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-3">
+                        <label class="form-label">Order</label>
+                        <input type="number" class="form-control" name="who_we[items][__INDEX__][order]">
+                    </div>
+                    @foreach ($locales as $locale)
+                        <div class="col-md-6">
+                            <label class="form-label">Title ({{ strtoupper($locale) }})</label>
+                            <input type="text" class="form-control" name="who_we[items][__INDEX__][title][{{ $locale }}]">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Text ({{ strtoupper($locale) }})</label>
+                            <textarea class="form-control" rows="3" name="who_we[items][__INDEX__][text][{{ $locale }}]"></textarea>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Bullets ({{ strtoupper($locale) }})</label>
+                            <textarea class="form-control" rows="3" name="who_we[items][__INDEX__][bullets][{{ $locale }}]"></textarea>
+                            <small class="text-muted">Enter each bullet on a new line.</small>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </template>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const addButton = document.getElementById('add-who-item');
+            const container = document.getElementById('who-items-container');
+            const template = document.getElementById('who-item-template');
+
+            if (addButton && container && template) {
+                addButton.addEventListener('click', function () {
+                    const index = Date.now();
+                    const wrapper = document.createElement('div');
+                    wrapper.innerHTML = template.innerHTML.replace(/__INDEX__/g, index).trim();
+                    container.appendChild(wrapper.firstElementChild);
+                });
+            }
+
+            container?.addEventListener('click', function (event) {
+                if (event.target.classList.contains('remove-who-item')) {
+                    event.target.closest('.who-item').remove();
+                }
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/admin/layouts/sidebar.blade.php
+++ b/resources/views/admin/layouts/sidebar.blade.php
@@ -71,31 +71,8 @@
                         </ul>
                     </div>
                 </li>
-                            <li
-                    class="sidebar-dropdown {{ Request::is('dashboard/cms/pages/*') ? 'active' : '' }}">
-                    <a href="#">
-                        <i class="fas fa-sitemap" aria-hidden="true"></i>
-                        <span class="menu-text">{{ __('admin.sidebar.website_cms') }}</span>
-                    </a>
-                    <div class="sidebar-submenu">
-                        <ul>
-                            <li class="{{ Request::is('dashboard/cms/pages/home/edit') ? 'active' : '' }}">
-                                <a href="{{ route('admin.cms.pages.edit', ['lang' => app()->getLocale(), 'slug' => 'home']) }}"
-                                    class="{{ Request::is('dashboard/cms/pages/home/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.home_page') }}</a>
-                            </li>
-                            <li class="{{ Request::is('dashboard/cms/pages/whoweare/edit') ? 'active' : '' }}">
-                                <a href="{{ route('admin.cms.pages.edit', ['lang' => app()->getLocale(), 'slug' => 'whoweare']) }}"
-                                    class="{{ Request::is('dashboard/cms/pages/whoweare/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.who_we_are') }}</a>
-                            </li>
-                            <li class="{{ Request::is('dashboard/cms/pages/contact-us/edit') ? 'active' : '' }}">
-                                <a href="{{ route('admin.cms.pages.edit', ['lang' => app()->getLocale(), 'slug' => 'contact-us']) }}"
-                                    class="{{ Request::is('dashboard/cms/pages/contact-us/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.contact_us') }}</a>
-                            </li>
-                        </ul>
-                    </div>
-                </li>
                 <li
-                    class="sidebar-dropdown {{ Request::is('dashboard/contact-submissions*') ? 'active' : '' }}">
+                    class="sidebar-dropdown {{ Request::is('dashboard/contact-submissions*') || Request::is('dashboard/cms/home/edit') || Request::is('dashboard/cms/whoweare/edit') || Request::is('dashboard/cms/contact-us/edit') || Request::is('*admin-panel/cms/home/*') || Request::is('*admin-panel/cms/whoweare/*') || Request::is('*admin-panel/cms/contact-us/*') ? 'active' : '' }}">
                     <a href="#">
                         <i class="fas fa-inbox" aria-hidden="true"></i>
                         <span class="menu-text">{{ __('admin.sidebar.contact_submissions') }}</span>
@@ -106,9 +83,22 @@
                                 <a href="{{ route('admin.contact_submissions.index', ['lang' => app()->getLocale()]) }}"
                                     class="{{ Request::is('dashboard/contact-submissions') ? 'current-page' : '' }}">{{ __('admin.sidebar.all_submissions') }}</a>
                             </li>
+                            <li class="{{ Request::is('dashboard/cms/home/edit') || Request::is('*admin-panel/cms/home/edit') ? 'active' : '' }}">
+                                <a href="{{ route('admin.cms.home.edit', ['lang' => app()->getLocale()]) }}"
+                                    class="{{ Request::is('dashboard/cms/home/edit') || Request::is('*admin-panel/cms/home/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.home_page') }}</a>
+                            </li>
+                            <li class="{{ Request::is('dashboard/cms/whoweare/edit') || Request::is('*admin-panel/cms/whoweare/edit') ? 'active' : '' }}">
+                                <a href="{{ route('admin.cms.whoweare.edit', ['lang' => app()->getLocale()]) }}"
+                                    class="{{ Request::is('dashboard/cms/whoweare/edit') || Request::is('*admin-panel/cms/whoweare/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.who_we_are') }}</a>
+                            </li>
+                            <li class="{{ Request::is('dashboard/cms/contact-us/edit') || Request::is('*admin-panel/cms/contact-us/edit') ? 'active' : '' }}">
+                                <a href="{{ route('admin.cms.contact.edit', ['lang' => app()->getLocale()]) }}"
+                                    class="{{ Request::is('dashboard/cms/contact-us/edit') || Request::is('*admin-panel/cms/contact-us/edit') ? 'current-page' : '' }}">{{ __('admin.sidebar.contact_us') }}</a>
+                            </li>
                         </ul>
                     </div>
-                </li></ul>
+                </li>
+            </ul>
         </div>
         <!-- sidebar menu end -->
     </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -14,9 +14,12 @@ use App\Http\Controllers\Admin\{
     RoleController
 };
 use App\Http\Controllers\Admin\Cms\{
+    ContactUsPageContentController,
+    HomePageContentController,
     PageController,
     PageSectionController,
     SectionItemController,
+    WhoWeArePageContentController,
 };
 use Illuminate\Support\Facades\Route;
 
@@ -85,8 +88,30 @@ Route::group([
     'where' => ['lang' => 'en|ar'],
     'middleware' => ['auth:admin'],
 ], function () {
-    // Pages edit
-    Route::get('/cms/pages/{slug}/edit', [PageController::class, 'edit'])->name('cms.pages.edit');
+    Route::prefix('cms')->as('cms.')->group(function () {
+        Route::get('/home/edit', [HomePageContentController::class, 'edit'])->name('home.edit');
+        Route::put('/home', [HomePageContentController::class, 'update'])->name('home.update');
+
+        Route::get('/whoweare/edit', [WhoWeArePageContentController::class, 'edit'])->name('whoweare.edit');
+        Route::put('/whoweare', [WhoWeArePageContentController::class, 'update'])->name('whoweare.update');
+
+        Route::get('/contact-us/edit', [ContactUsPageContentController::class, 'edit'])->name('contact.edit');
+        Route::put('/contact-us', [ContactUsPageContentController::class, 'update'])->name('contact.update');
+    });
+
+    Route::get('/cms/pages/{slug}/edit', function (?string $lang, string $slug) {
+        $targets = [
+            'home' => 'admin.cms.home.edit',
+            'whoweare' => 'admin.cms.whoweare.edit',
+            'contact-us' => 'admin.cms.contact.edit',
+        ];
+
+        if (!array_key_exists($slug, $targets)) {
+            abort(404);
+        }
+
+        return redirect()->route($targets[$slug], ['lang' => $lang]);
+    })->name('cms.pages.edit');
 
     // Sections
     Route::patch('/cms/sections/{section}/toggle', [PageSectionController::class, 'toggle'])->name('cms.sections.toggle');

--- a/tests/Feature/Admin/CmsPagesTest.php
+++ b/tests/Feature/Admin/CmsPagesTest.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\PageSection;
+use Database\Seeders\ContactUsPageSeeder;
+use Database\Seeders\HomePageSeeder;
+use Database\Seeders\WhoWeArePageSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class CmsPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(HomePageSeeder::class);
+        $this->seed(WhoWeArePageSeeder::class);
+        $this->seed(ContactUsPageSeeder::class);
+
+        $this->admin = Admin::create([
+            'first_name' => 'Test',
+            'last_name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => 'password',
+            'mobile' => '1234567890',
+        ]);
+    }
+
+    protected function actingAsAdmin()
+    {
+        return $this->actingAs($this->admin, 'admin');
+    }
+
+    public function test_home_edit_screen_is_accessible(): void
+    {
+        $response = $this->actingAsAdmin()->get(route('admin.cms.home.edit', ['lang' => 'en']));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.cms.home.edit');
+    }
+
+    public function test_home_page_sections_can_be_updated(): void
+    {
+        $bannerVideo = UploadedFile::fake()->create('banner.mp4', 1200, 'video/mp4');
+        $partnerImage = UploadedFile::fake()->image('partner.png');
+        $statIcon = UploadedFile::fake()->image('stat.png');
+        $whereImage = UploadedFile::fake()->image('where.png');
+        $brochurePdf = UploadedFile::fake()->create('brochure.pdf', 500, 'application/pdf');
+        $brochureIcon = UploadedFile::fake()->image('icon.png');
+        $ctaImage = UploadedFile::fake()->image('cta.png');
+        $ctaOverlay = UploadedFile::fake()->image('cta-overlay.png');
+
+        $partnerSection = PageSection::where('type', 'partners')->first();
+        $partnerItems = $partnerSection->items()->orderBy('order')->get();
+        $partnersPayload = [];
+        foreach ($partnerItems as $index => $item) {
+            $en = $item->getTranslation('data', 'en', true);
+            $partnersPayload[$index] = [
+                'id' => $item->id,
+                'order' => $index + 1,
+                'existing_image' => $en['image_path'] ?? null,
+                'alt' => [
+                    'en' => "Partner {$item->id}",
+                    'ar' => "شريك {$item->id}",
+                ],
+            ];
+            if ($index === 0) {
+                $partnersPayload[$index]['image'] = $partnerImage;
+            }
+        }
+
+        $statsSection = PageSection::where('type', 'stats')->first();
+        $statsItems = $statsSection->items()->orderBy('order')->get();
+        $statsPayload = [];
+        foreach ($statsItems as $index => $item) {
+            $en = $item->getTranslation('data', 'en', true);
+            $statsPayload[$index] = [
+                'id' => $item->id,
+                'order' => $index + 5,
+                'existing_icon' => $en['icon_path'] ?? null,
+                'number' => [
+                    'en' => "N{$item->id}",
+                    'ar' => "ع{$item->id}",
+                ],
+                'label' => [
+                    'en' => "Label {$item->id}",
+                    'ar' => "عنوان {$item->id}",
+                ],
+            ];
+            if ($index === 0) {
+                $statsPayload[$index]['icon'] = $statIcon;
+            }
+        }
+
+        $whereSection = PageSection::where('type', 'where_us')->first();
+        $whereItems = $whereSection->items()->orderBy('order')->get();
+        $wherePayload = [];
+        foreach ($whereItems as $index => $item) {
+            $en = $item->getTranslation('data', 'en', true);
+            $wherePayload[$index] = [
+                'id' => $item->id,
+                'order' => $index + 1,
+                'existing_image' => $en['image_path'] ?? null,
+                'overlay' => [
+                    'en' => "Overlay {$item->id}",
+                    'ar' => "طبقة {$item->id}",
+                ],
+            ];
+            if ($index === 0) {
+                $wherePayload[$index]['image'] = $whereImage;
+            }
+        }
+
+        $response = $this->actingAsAdmin()->put(route('admin.cms.home.update', ['lang' => 'en']), [
+            'banner' => [
+                'video' => $bannerVideo,
+                'autoplay' => '1',
+                'loop' => '1',
+                'muted' => '0',
+                'controls' => '1',
+                'playsinline' => '1',
+            ],
+            'partners' => [
+                'items' => array_values($partnersPayload),
+            ],
+            'about' => [
+                'en' => [
+                    'title' => 'About EN',
+                    'desc' => 'English description',
+                    'readmore_text' => 'Read EN',
+                    'readmore_link' => '/en/about',
+                ],
+                'ar' => [
+                    'title' => 'نبذة',
+                    'desc' => 'وصف عربي',
+                    'readmore_text' => 'اقرأ المزيد',
+                    'readmore_link' => '/ar/about',
+                ],
+            ],
+            'stats' => [
+                'items' => array_values($statsPayload),
+            ],
+            'where_us' => [
+                'title' => ['en' => 'Where EN', 'ar' => 'أين'],
+                'brochure_text' => ['en' => 'Download EN', 'ar' => 'حمل بالعربي'],
+                'brochure_icon' => $brochureIcon,
+                'brochure_file' => $brochurePdf,
+                'brochure_link' => 'https://example.com/brochure.pdf',
+                'items' => array_values($wherePayload),
+            ],
+            'cta' => [
+                'image' => $ctaImage,
+                'overlay_image' => $ctaOverlay,
+                'en' => [
+                    'title' => 'CTA EN',
+                    'text' => 'Call to action EN',
+                    'link_text' => 'Contact EN',
+                    'link_url' => '/contact-en',
+                ],
+                'ar' => [
+                    'title' => 'CTA AR',
+                    'text' => 'دعوة للعمل',
+                    'link_text' => 'تواصل',
+                    'link_url' => '/contact-ar',
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect(route('admin.cms.home.edit', ['lang' => 'en']));
+        $response->assertSessionHas('success');
+
+        $bannerSection = PageSection::where('type', 'banner')->first();
+        $bannerData = $bannerSection->getTranslation('section_data', 'en', true);
+        $this->assertStringContainsString('cms/home/banner', $bannerData['video_path'] ?? '');
+        $this->assertFileExists(public_path($bannerData['video_path']));
+        $this->assertTrue((bool) ($bannerData['autoplay'] ?? false));
+        $this->assertTrue((bool) ($bannerData['controls'] ?? false));
+
+        $partnerSection->refresh();
+        foreach ($partnerSection->items as $item) {
+            $data = $item->getTranslation('data', 'en', true);
+            $this->assertStringContainsString('Partner', $data['alt'] ?? '');
+        }
+
+        $statsSection->refresh();
+        foreach ($statsSection->items as $item) {
+            $data = $item->getTranslation('data', 'en', true);
+            $this->assertStringContainsString('Label', $data['label'] ?? '');
+        }
+
+        $whereSection->refresh();
+        $whereData = $whereSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('Where EN', $whereData['title']);
+        $this->assertStringContainsString('cms/home/where-us', $whereData['brochure']['icon_path'] ?? '');
+        $this->assertFileExists(public_path($whereData['brochure']['icon_path']));
+        $this->assertFileExists(public_path($whereData['brochure']['brochure_path']));
+
+        $ctaSection = PageSection::where('type', 'cta')->first();
+        $ctaData = $ctaSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('CTA EN', $ctaData['title']);
+        $this->assertFileExists(public_path($ctaData['image_path']));
+        $this->assertFileExists(public_path($ctaData['overlay_image_path']));
+    }
+
+    public function test_whoweare_page_can_be_updated(): void
+    {
+        $bannerImage = UploadedFile::fake()->image('second-banner.png');
+        $portImage = UploadedFile::fake()->image('port.png');
+
+        $featuresSection = PageSection::where('type', 'who_we')->first();
+        $items = $featuresSection->items()->orderBy('order')->get();
+        $featuresPayload = [];
+        foreach ($items as $index => $item) {
+            $featuresPayload[$index] = [
+                'id' => $item->id,
+                'order' => $index + 1,
+                'title' => [
+                    'en' => "Feature {$item->id}",
+                    'ar' => "ميزة {$item->id}",
+                ],
+                'text' => [
+                    'en' => "Feature description {$item->id}",
+                    'ar' => "وصف {$item->id}",
+                ],
+                'bullets' => [
+                    'en' => "Point 1\nPoint 2",
+                    'ar' => "نقطة 1\nنقطة 2",
+                ],
+            ];
+        }
+
+        $response = $this->actingAsAdmin()->put(route('admin.cms.whoweare.update', ['lang' => 'en']), [
+            'banner' => ['image' => $bannerImage],
+            'who_we' => [
+                'en' => [
+                    'title' => 'Who EN',
+                    'description' => 'Who description EN',
+                ],
+                'ar' => [
+                    'title' => 'من نحن',
+                    'description' => 'وصف من نحن',
+                ],
+                'items' => array_values($featuresPayload),
+            ],
+            'port' => ['image' => $portImage],
+        ]);
+
+        $response->assertRedirect(route('admin.cms.whoweare.edit', ['lang' => 'en']));
+        $response->assertSessionHas('success');
+
+        $bannerSection = PageSection::where('type', 'second_banner')->first();
+        $bannerData = $bannerSection->getTranslation('section_data', 'en', true);
+        $this->assertFileExists(public_path($bannerData['image_path']));
+
+        $featuresSection->refresh();
+        $featuresData = $featuresSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('Who EN', $featuresData['title']);
+        foreach ($featuresSection->items as $item) {
+            $data = $item->getTranslation('data', 'en', true);
+            $this->assertEquals(['Point 1', 'Point 2'], $data['bullets'] ?? []);
+        }
+
+        $portSection = PageSection::where('type', 'port_image')->first();
+        $portData = $portSection->getTranslation('section_data', 'en', true);
+        $this->assertFileExists(public_path($portData['image_path']));
+    }
+
+    public function test_contact_page_can_be_updated(): void
+    {
+        $bannerImage = UploadedFile::fake()->image('contact-banner.png');
+        $mapImage = UploadedFile::fake()->image('map.png');
+        $bottomImage = UploadedFile::fake()->image('bottom.png');
+        $adsImage1 = UploadedFile::fake()->image('ads1.png');
+        $adsImage2 = UploadedFile::fake()->image('ads2.png');
+        $screensImage1 = UploadedFile::fake()->image('screens1.png');
+        $screensImage2 = UploadedFile::fake()->image('screens2.png');
+        $createImage1 = UploadedFile::fake()->image('create1.png');
+        $createImage2 = UploadedFile::fake()->image('create2.png');
+        $faqImage1 = UploadedFile::fake()->image('faq1.png');
+        $faqImage2 = UploadedFile::fake()->image('faq2.png');
+
+        $forms = [
+            'ads' => PageSection::where('type', 'contact_form_ads')->first(),
+            'screens' => PageSection::where('type', 'contact_form_screens')->first(),
+            'create' => PageSection::where('type', 'contact_form_create')->first(),
+            'faq' => PageSection::where('type', 'contact_form_faq')->first(),
+        ];
+
+        $formPayload = [];
+        foreach ($forms as $key => $section) {
+            $dataEn = $section->getTranslation('section_data', 'en', true);
+            $dataAr = $section->getTranslation('section_data', 'ar', true);
+            $formPayload[$key] = [
+                'card_image1' => null,
+                'card_image2' => null,
+                'en' => [
+                    'card_text' => "Updated EN {$key}",
+                    'modal_title' => "Modal EN {$key}",
+                    'submit_text' => "Submit EN {$key}",
+                    'labels' => array_map(fn () => 'Label EN', $dataEn['labels'] ?? []),
+                    'radio' => array_map(fn () => 'Radio EN', $dataEn['radio'] ?? []),
+                    'options' => array_map(fn ($values) => implode("\n", (array) $values), $dataEn['options'] ?? []),
+                ],
+                'ar' => [
+                    'card_text' => "تحديث {$key}",
+                    'modal_title' => "عنوان {$key}",
+                    'submit_text' => "إرسال {$key}",
+                    'labels' => array_map(fn () => 'حقل', $dataAr['labels'] ?? []),
+                    'radio' => array_map(fn () => 'اختيار', $dataAr['radio'] ?? []),
+                    'options' => array_map(fn ($values) => implode("\n", (array) $values), $dataAr['options'] ?? []),
+                ],
+            ];
+        }
+
+        $formPayload['ads']['card_image1'] = $adsImage1;
+        $formPayload['ads']['card_image2'] = $adsImage2;
+        $formPayload['screens']['card_image1'] = $screensImage1;
+        $formPayload['screens']['card_image2'] = $screensImage2;
+        $formPayload['create']['card_image1'] = $createImage1;
+        $formPayload['create']['card_image2'] = $createImage2;
+        $formPayload['faq']['card_image1'] = $faqImage1;
+        $formPayload['faq']['card_image2'] = $faqImage2;
+
+        $payload = [
+            'banner' => ['image' => $bannerImage],
+            'contact' => [
+                'en' => ['title' => 'Contact EN', 'subtitle' => 'Subtitle EN'],
+                'ar' => ['title' => 'تواصل', 'subtitle' => 'نص فرعي'],
+            ],
+            'map' => [
+                'background_image' => $mapImage,
+                'en' => [
+                    'title' => 'Map EN',
+                    'address' => 'Address EN',
+                    'phone_label' => 'Phone EN',
+                    'whatsapp_label' => 'WhatsApp EN',
+                ],
+                'ar' => [
+                    'title' => 'خريطة',
+                    'address' => 'عنوان',
+                    'phone_label' => 'هاتف',
+                    'whatsapp_label' => 'واتساب',
+                ],
+            ],
+            'bottom' => ['image' => $bottomImage],
+            'contact_forms' => [],
+        ];
+
+        foreach ($formPayload as $key => $form) {
+            $payload['contact_forms'][$key] = [
+                'card_image1' => $form['card_image1'],
+                'card_image2' => $form['card_image2'],
+                'en' => $form['en'],
+                'ar' => $form['ar'],
+            ];
+        }
+
+        $response = $this->actingAsAdmin()->put(route('admin.cms.contact.update', ['lang' => 'en']), $payload);
+
+        $response->assertRedirect(route('admin.cms.contact.edit', ['lang' => 'en']));
+        $response->assertSessionHas('success');
+
+        $bannerSection = PageSection::where('type', 'second_banner')->first();
+        $bannerData = $bannerSection->getTranslation('section_data', 'en', true);
+        $this->assertFileExists(public_path($bannerData['image_path']));
+
+        $mapSection = PageSection::where('type', 'map')->first();
+        $mapData = $mapSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('Map EN', $mapData['title']);
+        $this->assertFileExists(public_path($mapData['background_image_path']));
+
+        $adsSection = $forms['ads']->fresh();
+        $adsData = $adsSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('Updated EN ads', $adsData['card_text']);
+        $this->assertFileExists(public_path($adsData['card_image1']));
+        $this->assertFileExists(public_path($adsData['card_image2']));
+
+        $faqSection = $forms['faq']->fresh();
+        $faqData = $faqSection->getTranslation('section_data', 'en', true);
+        $this->assertEquals('Updated EN faq', $faqData['card_text']);
+    }
+}


### PR DESCRIPTION
## Summary
- implement dedicated CMS controllers for the home, who we are, and contact pages with section/file orchestration atop a shared base
- build tailored Blade edit forms for each page, leveraging the media upload component and dynamic section item controls
- extend file utilities, sidebar navigation, admin routing, and add feature tests covering multilingual updates and file handling

## Testing
- not run (composer install blocked by repeated 403 errors when attempting to download GitHub-hosted packages)


------
https://chatgpt.com/codex/tasks/task_e_68cd550eced48322985b8a6747e2f5e2