### PR TITLE
Add ad scheduler service with caching and playlist tests

### DIFF
--- a/app/Http/Resources/Api/Screens/PlaylistItemResource.php
+++ b/app/Http/Resources/Api/Screens/PlaylistItemResource.php
@@ -18,10 +18,16 @@ class PlaylistItemResource extends JsonResource
             'id' => $this->resource['id'],
             'ad_id' => $this->resource['ad_id'] ?? $this->resource['id'],
             'file_path' => $this->resource['file_path'],
+            'file_url' => $this->resource['file_url'] ?? null,
             'file_type' => $this->resource['file_type'],
             'duration_seconds' => $this->resource['duration_seconds'],
             'play_order' => $this->resource['play_order'],
+            'schedule_id' => $this->resource['schedule_id'] ?? null,
             'schedule' => $this->resource['schedule'],
+            'valid_from' => $this->resource['valid_from'] ?? null,
+            'valid_until' => $this->resource['valid_until'] ?? null,
+            'ad_valid_from' => $this->resource['ad_valid_from'] ?? null,
+            'ad_valid_until' => $this->resource['ad_valid_until'] ?? null,
         ];
     }
 }

--- a/app/Observers/AdObserver.php
+++ b/app/Observers/AdObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Ad;
+use App\Services\Screen\AdSchedulerService;
+
+class AdObserver
+{
+    public function __construct(
+        protected AdSchedulerService $scheduler
+    ) {
+    }
+
+    public function saved(Ad $ad): void
+    {
+        $this->flushScreens($ad);
+    }
+
+    public function deleted(Ad $ad): void
+    {
+        $this->flushScreens($ad);
+    }
+
+    protected function flushScreens(Ad $ad): void
+    {
+        $screenIds = $ad->screens()->pluck('screens.id')->all();
+
+        if (!empty($screenIds)) {
+            $this->scheduler->forgetMany($screenIds);
+        }
+    }
+}

--- a/app/Observers/AdScheduleObserver.php
+++ b/app/Observers/AdScheduleObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\AdSchedule;
+use App\Services\Screen\AdSchedulerService;
+
+class AdScheduleObserver
+{
+    public function __construct(
+        protected AdSchedulerService $scheduler
+    ) {
+    }
+
+    public function saved(AdSchedule $schedule): void
+    {
+        $this->flushScreens($schedule);
+    }
+
+    public function deleted(AdSchedule $schedule): void
+    {
+        $this->flushScreens($schedule);
+    }
+
+    protected function flushScreens(AdSchedule $schedule): void
+    {
+        $screenIds = array_filter([
+            $schedule->screen_id,
+            $schedule->getOriginal('screen_id'),
+        ]);
+
+        if (!empty($screenIds)) {
+            $this->scheduler->forgetMany($screenIds);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,19 +6,23 @@ use App\Contracts\FileServiceInterface;
 use App\Helpers\ComponentHelper;
 use App\Services\FileService;
 use App\Services\LayoutService;
-use App\Models\SeoMeta;
+use App\Models\Ad;
+use App\Models\AdSchedule;
 use App\Models\Menu;
 use App\Models\MenuItem;
-use App\Models\Setting;
 use App\Models\Page;
 use App\Models\PageSection;
 use App\Models\SectionItem;
-use App\Observers\MenuObserver;
+use App\Models\SeoMeta;
+use App\Models\Setting;
+use App\Observers\AdObserver;
+use App\Observers\AdScheduleObserver;
 use App\Observers\MenuItemObserver;
-use App\Observers\SettingObserver;
+use App\Observers\MenuObserver;
 use App\Observers\PageObserver;
 use App\Observers\PageSectionObserver;
 use App\Observers\SectionItemObserver;
+use App\Observers\SettingObserver;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
@@ -54,6 +58,8 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // Register model observers that invalidate cached layout/page data
+        Ad::observe(AdObserver::class);
+        AdSchedule::observe(AdScheduleObserver::class);
         Menu::observe(MenuObserver::class);
         MenuItem::observe(MenuItemObserver::class);
         Setting::observe(SettingObserver::class);

--- a/app/Services/Screen/AdSchedulerService.php
+++ b/app/Services/Screen/AdSchedulerService.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace App\Services\Screen;
+
+use App\Enums\AdStatus;
+use App\Models\Ad;
+use App\Models\AdSchedule;
+use App\Models\Screen;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+class AdSchedulerService
+{
+    public function __construct(
+        private readonly Repository $cache
+    ) {
+    }
+
+    /**
+     * Retrieve the cached playlist payload for the provided screen.
+     *
+     * @return array<string, mixed>
+     */
+    public function forScreen(Screen $screen): array
+    {
+        $screen = $screen->fresh();
+
+        if (!$screen) {
+            return [
+                'screen' => null,
+                'items' => [],
+                'etag' => '',
+                'generated_at' => now(),
+                'expires_at' => now()->addSeconds($this->ttl()),
+            ];
+        }
+
+        $key = $this->cacheKey($screen->id);
+
+        $payload = $this->cache->get($key);
+
+        if (!is_array($payload)) {
+            $payload = $this->buildPayload($screen);
+            $this->cache->put($key, $payload, $this->ttl());
+        } else {
+            $etag = $this->makeEtag($screen, $payload['items'] ?? []);
+
+            if (($payload['etag'] ?? null) !== $etag) {
+                $payload['etag'] = $etag;
+                $payload['generated_at'] = now();
+                $payload['expires_at'] = (clone $payload['generated_at'])->addSeconds($this->ttl());
+
+                $this->cache->put($key, $payload, $this->ttl());
+            }
+        }
+
+        return array_merge($payload, [
+            'screen' => $screen,
+        ]);
+    }
+
+    /**
+     * Persist the computed playlist payload into the cache.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function put(Screen $screen, array $payload): void
+    {
+        $this->cache->put(
+            $this->cacheKey($screen->id),
+            Arr::except($payload, ['screen']),
+            $this->ttl()
+        );
+    }
+
+    /**
+     * Forget the cached playlist entry for the provided screen.
+     */
+    public function forget(Screen|int $screen): void
+    {
+        $screenId = $screen instanceof Screen ? $screen->id : $screen;
+
+        if ($screenId) {
+            $this->cache->forget($this->cacheKey((int) $screenId));
+        }
+    }
+
+    /**
+     * Forget cached playlists for multiple screens.
+     *
+     * @param  iterable<int, int|string>  $screenIds
+     */
+    public function forgetMany(iterable $screenIds): void
+    {
+        foreach (collect($screenIds)->filter()->unique() as $id) {
+            $this->forget((int) $id);
+        }
+    }
+
+    /**
+     * Build the playlist payload for the screen.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildPayload(Screen $screen): array
+    {
+        $items = $this->buildItems($screen);
+        $generatedAt = now();
+        $expiresAt = (clone $generatedAt)->addSeconds($this->ttl());
+
+        return [
+            'items' => $items,
+            'etag' => $this->makeEtag($screen, $items),
+            'generated_at' => $generatedAt,
+            'expires_at' => $expiresAt,
+        ];
+    }
+
+    /**
+     * Build the playlist items for the screen.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildItems(Screen $screen): array
+    {
+        $screenId = $screen->id;
+
+        $screen->loadMissing([
+            'ads' => function ($query): void {
+                $query->withPivot('play_order')
+                    ->orderBy('ad_screen.play_order');
+            },
+            'ads.schedules' => function ($query) use ($screenId): void {
+                $query->where('screen_id', $screenId)
+                    ->orderBy('start_time');
+            },
+        ]);
+
+        $now = now();
+
+        $eligibleAds = $screen->ads
+            ->filter(fn (Ad $ad) => $this->adIsEligible($ad, $now))
+            ->values();
+
+        $scheduled = $eligibleAds
+            ->map(function (Ad $ad) use ($now) {
+                $schedule = $ad->schedules
+                    ->filter(fn (AdSchedule $schedule) => $this->scheduleIsActive($schedule, $now))
+                    ->sortBy('start_time')
+                    ->first();
+
+                if (!$schedule) {
+                    return null;
+                }
+
+                return $this->makeItem($ad, $schedule);
+            })
+            ->filter()
+            ->values();
+
+        $scheduledAdIds = $scheduled->pluck('ad_id')->unique();
+
+        $fallback = $eligibleAds
+            ->reject(fn (Ad $ad) => $scheduledAdIds->contains($ad->id))
+            ->map(fn (Ad $ad) => $this->makeItem($ad, null))
+            ->values();
+
+        return $scheduled
+            ->merge($fallback)
+            ->sortBy('play_order')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Determine if the ad is eligible for playback at the given moment.
+     */
+    protected function adIsEligible(Ad $ad, Carbon $moment): bool
+    {
+        if ($ad->status !== AdStatus::Active) {
+            return false;
+        }
+
+        if ($ad->start_date && $ad->start_date->greaterThan($moment)) {
+            return false;
+        }
+
+        if ($ad->end_date && $ad->end_date->lessThan($moment)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the schedule is currently active.
+     */
+    protected function scheduleIsActive(AdSchedule $schedule, Carbon $moment): bool
+    {
+        if (!$schedule->is_active) {
+            return false;
+        }
+
+        if ($schedule->start_time && $schedule->start_time->greaterThan($moment)) {
+            return false;
+        }
+
+        if ($schedule->end_time && $schedule->end_time->lessThan($moment)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Build the playlist item payload for the ad/schedule combination.
+     *
+     * @return array<string, mixed>
+     */
+    protected function makeItem(Ad $ad, ?AdSchedule $schedule): array
+    {
+        $playOrder = (int) ($ad->pivot->play_order ?? 0);
+
+        return [
+            'id' => $ad->id,
+            'ad_id' => $ad->id,
+            'file_path' => $ad->file_path,
+            'file_url' => $ad->file_url,
+            'file_type' => $ad->file_type,
+            'duration_seconds' => (int) $ad->duration_seconds,
+            'play_order' => $playOrder,
+            'schedule_id' => $schedule?->id,
+            'schedule' => $schedule ? [
+                'id' => $schedule->id,
+                'start_time' => optional($schedule->start_time)->toAtomString(),
+                'end_time' => optional($schedule->end_time)->toAtomString(),
+                'is_active' => (bool) $schedule->is_active,
+            ] : null,
+            'valid_from' => $schedule
+                ? optional($schedule->start_time)->toAtomString()
+                : optional($ad->start_date)->toAtomString(),
+            'valid_until' => $schedule
+                ? optional($schedule->end_time)->toAtomString()
+                : optional($ad->end_date)->toAtomString(),
+            'ad_valid_from' => optional($ad->start_date)->toAtomString(),
+            'ad_valid_until' => optional($ad->end_date)->toAtomString(),
+        ];
+    }
+
+    /**
+     * Generate an ETag for the playlist payload.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    protected function makeEtag(Screen $screen, array $items): string
+    {
+        $payload = json_encode($items, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return sha1($screen->id.'|'.($screen->updated_at?->timestamp ?? 0).'|'.$payload);
+    }
+
+    /**
+     * Resolve the cache key for the playlist entry.
+     */
+    protected function cacheKey(int $screenId): string
+    {
+        return "playlist:{$screenId}";
+    }
+
+    /**
+     * Resolve the cache TTL in seconds.
+     */
+    protected function ttl(): int
+    {
+        return max(1, (int) config('services.screens.playlist_ttl', 300));
+    }
+}

--- a/tests/Unit/Services/Screen/AdSchedulerServiceTest.php
+++ b/tests/Unit/Services/Screen/AdSchedulerServiceTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit\Services\Screen;
+
+use App\Enums\AdStatus;
+use App\Enums\PlaceType;
+use App\Models\Ad;
+use App\Models\Place;
+use App\Models\Screen;
+use App\Models\User;
+use App\Services\Screen\AdSchedulerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class AdSchedulerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            Cache::clear();
+        } catch (\BadMethodCallException) {
+            Cache::flush();
+        }
+        config(['services.screens.playlist_ttl' => 300]);
+        config(['app.url' => 'https://example.test']);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_for_screen_returns_scheduled_and_fallback_items(): void
+    {
+        $now = Carbon::create(2024, 1, 1, 12, 0, 0);
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+        $place = Place::create([
+            'name' => ['en' => 'Test Place'],
+            'address' => ['en' => '123 Street'],
+            'type' => PlaceType::Cafe,
+        ]);
+        $screen = Screen::create([
+            'place_id' => $place->id,
+            'code' => 'SCR-001',
+        ]);
+
+        $scheduledAd = Ad::create([
+            'title' => ['en' => 'Scheduled'],
+            'description' => ['en' => 'Scheduled Ad'],
+            'file_path' => 'upload/ads/scheduled.mp4',
+            'file_type' => 'video',
+            'duration_seconds' => 30,
+            'status' => AdStatus::Active,
+            'created_by' => $user->id,
+            'approved_by' => $user->id,
+            'start_date' => $now->copy()->subDay(),
+            'end_date' => $now->copy()->addDay(),
+        ]);
+        $fallbackAd = Ad::create([
+            'title' => ['en' => 'Fallback'],
+            'description' => ['en' => 'Fallback Ad'],
+            'file_path' => 'upload/ads/fallback.png',
+            'file_type' => 'image',
+            'duration_seconds' => 15,
+            'status' => AdStatus::Active,
+            'created_by' => $user->id,
+            'approved_by' => $user->id,
+            'start_date' => $now->copy()->subHours(2),
+            'end_date' => $now->copy()->addHours(6),
+        ]);
+        $inactiveAd = Ad::create([
+            'title' => ['en' => 'Inactive'],
+            'description' => ['en' => 'Inactive Ad'],
+            'file_path' => 'upload/ads/inactive.png',
+            'file_type' => 'image',
+            'duration_seconds' => 10,
+            'status' => AdStatus::Pending,
+            'created_by' => $user->id,
+            'approved_by' => $user->id,
+            'start_date' => $now->copy()->subHours(2),
+            'end_date' => $now->copy()->addHours(2),
+        ]);
+
+        $screen->ads()->attach($scheduledAd->id, ['play_order' => 1]);
+        $screen->ads()->attach($fallbackAd->id, ['play_order' => 2]);
+        $screen->ads()->attach($inactiveAd->id, ['play_order' => 3]);
+
+        $scheduledAd->schedules()->create([
+            'screen_id' => $screen->id,
+            'start_time' => $now->copy()->subHour(),
+            'end_time' => $now->copy()->addHour(),
+            'is_active' => true,
+        ]);
+        $fallbackAd->schedules()->create([
+            'screen_id' => $screen->id,
+            'start_time' => $now->copy()->addHour(),
+            'end_time' => $now->copy()->addHours(2),
+            'is_active' => true,
+        ]);
+
+        /** @var AdSchedulerService $scheduler */
+        $scheduler = app(AdSchedulerService::class);
+
+        $payload = $scheduler->forScreen($screen);
+
+        $this->assertInstanceOf(Screen::class, $payload['screen']);
+        $this->assertInstanceOf(Carbon::class, $payload['generated_at']);
+        $this->assertInstanceOf(Carbon::class, $payload['expires_at']);
+        $this->assertNotSame('', $payload['etag']);
+
+        $items = Collection::make($payload['items']);
+        $this->assertCount(2, $items); // inactive ad excluded
+        $this->assertSame([1, 2], $items->pluck('play_order')->all());
+
+        $scheduledItem = $items->firstWhere('ad_id', $scheduledAd->id);
+        $this->assertNotNull($scheduledItem);
+        $this->assertNotNull($scheduledItem['schedule']);
+        $this->assertSame($scheduledAd->file_url, $scheduledItem['file_url']);
+        $this->assertSame($scheduledAd->schedules()->first()->start_time->toAtomString(), $scheduledItem['valid_from']);
+        $this->assertSame($scheduledAd->start_date->toAtomString(), $scheduledItem['ad_valid_from']);
+
+        $fallbackItem = $items->firstWhere('ad_id', $fallbackAd->id);
+        $this->assertNotNull($fallbackItem);
+        $this->assertNull($fallbackItem['schedule']);
+        $this->assertSame($fallbackAd->start_date->toAtomString(), $fallbackItem['valid_from']);
+        $this->assertSame($fallbackAd->end_date->toAtomString(), $fallbackItem['valid_until']);
+
+        $this->assertTrue($payload['generated_at']->eq($now));
+        $this->assertTrue($payload['expires_at']->eq($now->copy()->addSeconds(config('services.screens.playlist_ttl'))));
+
+        Carbon::setTestNow($now->copy()->addMinutes(10));
+        $cached = $scheduler->forScreen($screen);
+        $this->assertEquals($payload['generated_at'], $cached['generated_at']);
+        $this->assertEquals($payload['etag'], $cached['etag']);
+
+        $scheduler->forget($screen);
+        Carbon::setTestNow($now->copy()->addMinutes(20));
+        $reloaded = $scheduler->forScreen($screen);
+        $this->assertTrue($reloaded['generated_at']->gt($cached['generated_at']));
+    }
+}

--- a/tests/Unit/Services/Screen/ScreenApiServiceTest.php
+++ b/tests/Unit/Services/Screen/ScreenApiServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit\Services\Screen;
+
+use App\Enums\AdStatus;
+use App\Enums\PlaceType;
+use App\Models\Ad;
+use App\Models\Place;
+use App\Models\Screen;
+use App\Models\User;
+use App\Services\Screen\ScreenApiService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class ScreenApiServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            Cache::clear();
+        } catch (\BadMethodCallException) {
+            Cache::flush();
+        }
+
+        config([
+            'services.screens.playlist_ttl' => 300,
+            'app.url' => 'https://example.test',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_playlist_uses_cached_payload_and_etag_handling(): void
+    {
+        $now = Carbon::create(2024, 1, 1, 9, 30, 0);
+        Carbon::setTestNow($now);
+
+        [$screen, $scheduledAd] = $this->createScreenWithAds($now);
+
+        /** @var ScreenApiService $service */
+        $service = app(ScreenApiService::class);
+
+        $first = $service->playlist($screen);
+        $this->assertInstanceOf(Collection::class, $first['items']);
+        $this->assertSame(2, $first['items']->count());
+        $this->assertFalse($first['unchanged']);
+        $this->assertNotSame('', $first['etag']);
+
+        $etag = $first['etag'];
+
+        Carbon::setTestNow($now->copy()->addMinutes(5));
+        $second = $service->playlist($screen, $etag);
+        $this->assertTrue($second['unchanged']);
+        $this->assertSame($etag, $second['etag']);
+
+        Carbon::setTestNow($now->copy()->addMinutes(10));
+        $scheduledAd->update([
+            'title' => ['en' => 'Updated Scheduled'],
+        ]);
+
+        $third = $service->playlist($screen, $etag);
+        $this->assertFalse($third['unchanged']);
+        $this->assertNotSame($etag, $third['etag']);
+    }
+
+    /**
+     * @return array{Screen, Ad}
+     */
+    private function createScreenWithAds(Carbon $now): array
+    {
+        $user = User::factory()->create();
+        $place = Place::create([
+            'name' => ['en' => 'Fixture Place'],
+            'address' => ['en' => '456 Avenue'],
+            'type' => PlaceType::Mall,
+        ]);
+
+        $screen = Screen::create([
+            'place_id' => $place->id,
+            'code' => 'SCR-200',
+        ]);
+
+        $scheduledAd = Ad::create([
+            'title' => ['en' => 'Scheduled'],
+            'description' => ['en' => 'Scheduled Ad'],
+            'file_path' => 'upload/ads/scheduled.mp4',
+            'file_type' => 'video',
+            'duration_seconds' => 30,
+            'status' => AdStatus::Active,
+            'created_by' => $user->id,
+            'approved_by' => $user->id,
+            'start_date' => $now->copy()->subDay(),
+            'end_date' => $now->copy()->addDay(),
+        ]);
+
+        $fallbackAd = Ad::create([
+            'title' => ['en' => 'Fallback'],
+            'description' => ['en' => 'Fallback Ad'],
+            'file_path' => 'upload/ads/fallback.png',
+            'file_type' => 'image',
+            'duration_seconds' => 20,
+            'status' => AdStatus::Active,
+            'created_by' => $user->id,
+            'approved_by' => $user->id,
+            'start_date' => $now->copy()->subHours(2),
+            'end_date' => $now->copy()->addHours(5),
+        ]);
+
+        $screen->ads()->attach($scheduledAd->id, ['play_order' => 1]);
+        $screen->ads()->attach($fallbackAd->id, ['play_order' => 2]);
+
+        $scheduledAd->schedules()->create([
+            'screen_id' => $screen->id,
+            'start_time' => $now->copy()->subMinutes(30),
+            'end_time' => $now->copy()->addHour(),
+            'is_active' => true,
+        ]);
+
+        return [$screen, $scheduledAd];
+    }
+}


### PR DESCRIPTION
## Summary
- add an AdSchedulerService that builds cached playlists with schedule/fallback logic
- update screen API playlist handling, observers, and resources to use the new scheduler
- expand API playlist payload to include URLs and validity metadata plus new unit tests

## Testing
- composer install --no-interaction *(fails: GitHub downloads blocked in environment)*
- php artisan test *(fails: GitHub downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98a000b483228abb05392e2ae239